### PR TITLE
Fix /var unmounting bug

### DIFF
--- a/src/modules/RootPart.ycp
+++ b/src/modules/RootPart.ycp
@@ -835,6 +835,7 @@ define string FindPartitionInFstab (list <map> & fstab, string mountpoint) {
 	// umount /var
 	if (fstab_has_separate_var) {
 	    SCR::Execute (.target.umount, Installation::destdir + "/var");
+	    activated = remove (activated, 0);
 	}
 
 	return true;


### PR DESCRIPTION
When a root partition has a separate /var partition, that /var
partition is mounted, added to the activated list, then unmounted.
The problem is that it is never removed from the activated list, thus
when all partitions are unmounted later on, an error occurs as YaST
tries to unmount it twice.
