### PR TITLE
updated BuildRequires: RNG schema moved to yast2-installation-control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ update.pot
 Makefile.am.common
 *.ami
 doc/autodocs/*.html
-control/update.glade

--- a/configure.in.in
+++ b/configure.in.in
@@ -8,8 +8,5 @@
 @YAST2-CHECKS-COMMON@
 @YAST2-CHECKS-YCP@
 
-## Nasty hack: xgettext doesn't work for XML files, so let's symlink it
-( cd control; ln -sf update.xml update.glade )
-
 ## and generate the output...
 @YAST2-OUTPUT@

--- a/control/Makefile.am
+++ b/control/Makefile.am
@@ -2,11 +2,7 @@
 # Makefile.am for control
 #
 
-controldir = $(yast2dir)/control
-
-control_DATA = $(wildcard *.xml)
-
-EXTRA_DIST = $(control_DATA)
+dist_control_DATA = $(wildcard *.xml)
 
 check-local:
-	xmllint --relaxng $(controldir)/control.rng --noout $(control_DATA)
+	xmllint --relaxng $(controldir)/control.rng --noout $(dist_control_DATA)

--- a/control/update.glade
+++ b/control/update.glade
@@ -1,0 +1,1 @@
+update.xml

--- a/doc/.cvsignore
+++ b/doc/.cvsignore
@@ -1,2 +1,0 @@
-Makefile
-Makefile.in

--- a/doc/autodocs/.cvsignore
+++ b/doc/autodocs/.cvsignore
@@ -1,3 +1,0 @@
-Makefile
-Makefile.in
-*.html

--- a/doc/autodocs/.gitignore
+++ b/doc/autodocs/.gitignore
@@ -1,0 +1,4 @@
+.yardoc/
+Yast/
+css/
+js/

--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Wed Dec 18 12:44:15 UTC 2013 - lslezak@suse.cz
+
+- updated BuildRequires: RNG schema for control files has been
+  moved to yast2-installation-control package
+- use %yast_controldir RPM macro
+- move the *.glade link to Git (allow creating POT from clean Git
+  checkout without need to run "make")
+- 3.1.2
+
+-------------------------------------------------------------------
 Wed Nov 13 15:56:18 UTC 2013 - jreidinger@suse.com
 
 - Add explicit COPYING file

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        3.1.1
+Version:        3.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -26,13 +26,13 @@ Source0:        %{name}-%{version}.tar.bz2
 Group:          System/YaST
 License:        GPL-2.0
 BuildRequires:	update-desktop-files
-BuildRequires:  yast2-devtools >= 3.1.10
+BuildRequires:  yast2-devtools >= 3.1.15
 
 # xmllint
-BuildRequires:	libxml2
+BuildRequires:	libxml2-tools
 
 # control.rng
-BuildRequires:	yast2-installation >= 2.17.44
+BuildRequires:	yast2-installation-control
 
 # Stroage::ChangeDmNamesFromCrypttab
 Requires:	yast2-storage >= 2.22.9
@@ -108,7 +108,7 @@ Use this component if you wish to update your system.
 %files FACTORY
 %defattr(-,root,root)
 %{yast_desktopdir}/update.desktop
-%dir /usr/share/YaST2/control
-/usr/share/YaST2/control/update.xml
+%dir %{yast_controldir}
+%{yast_controldir}/update.xml
 %{yast_clientdir}/update.rb
 %{yast_clientdir}/run_update.rb


### PR DESCRIPTION
additional cleanup:
- removed `.cvsignore`, updated `.gitignore`
- use `%yast_controldir` RPM macro
- move the `*.glade` link to Git (allow creating POT from clean Git
  checkout without need to run `make`)
- 3.1.2
