### PR TITLE
override the target distribution from the system (bnc#881320)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jun  6 13:35:01 UTC 2014 - lslezak@suse.cz
+
+- override the target distribution from the system, use the target
+  distribution from the base product so the service repositories
+  are compatible with the upgraded (future) product (bnc#881320)
+- 3.1.10
+
+-------------------------------------------------------------------
 Thu May 22 07:40:27 UTC 2014 - jsrain@suse.cz
 
 - allow to specify target for AutoYaST upgrade via boot

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        3.1.9
+Version:        3.1.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -48,6 +48,9 @@ Requires:	yast2-installation
 
 # Packages.default_patterns
 Requires:	yast2-packager >= 3.1.10
+
+# Pkg.TargetInitializeOptions()
+Requires:       yast2-pkg-bindings >= 3.1.14
 
 # moved into yast2-update from yast2-installation
 # to remove dependency on yast2-storage


### PR DESCRIPTION
use the target distribution from the base product so the service repositories
are compatible with the upgraded (future) product
- 3.1.10
