### PR TITLE
backup /var/lib/rpm at update (bnc#857639)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Mon Jul 28 14:12:31 UTC 2014 - lslezak@suse.cz
+
+- backup /var/lib/rpm at update to prevent from accidental
+  corruption (bnc#857639)
+- switch from bzip2 to gzip compression (slightly less compression
+  ratio, but much faster), use parallel gzip (pigz) for even
+  faster backup
+- 3.1.21
+
+-------------------------------------------------------------------
 Wed Jul 23 15:03:43 UTC 2014 - lslezak@suse.cz
 
 - update proposal: always select patterns to install, not only

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        3.1.20
+Version:        3.1.21
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -62,6 +62,9 @@ Conflicts:	yast2-pkg-bindings < 2.15.11
 Conflicts:	yast2-storage < 2.15.4
 
 Requires:       yast2-ruby-bindings >= 1.0.0
+
+# use parallel gzip when crating backup (much faster)
+Requires:       pigz
 
 Summary:	YaST2 - Update
 

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1808,6 +1808,7 @@ module Yast
     # backup them to restore if something goes wrong (bnc#882039)
     BACKUP_DIRS = {
       "sw_mgmt" => [
+        "/var/lib/rpm",
         "/etc/zypp/repos.d",
         "/etc/zypp/services.d",
         "/etc/zypp/credentials.d"

--- a/src/modules/Update.rb
+++ b/src/modules/Update.rb
@@ -858,7 +858,7 @@ module Yast
       log.info "Creating tarball for #{name} including #{paths}"
       mounted_root = Installation.destdir
 
-      tarball_path = File.join(BACKUP_DIR, "#{name}.tar.bz2")
+      tarball_path = File.join(BACKUP_DIR, "#{name}.tar.gz")
       root_tarball_path = File.join(mounted_root, tarball_path)
       create_tarball(root_tarball_path, mounted_root, paths)
 
@@ -935,10 +935,11 @@ module Yast
 
       paths_without_prefix = existing_paths.map {|p| p.start_with?("/") ? p[1..-1] : p }
 
-      command = "tar cjvf '#{tarball_path}'"
-      command << " -C '#{root}'"
+      command = "tar cv -C '#{root}'"
       # no shell escaping here, but we backup reasonable files and want to allow globs
       command << " " + paths_without_prefix.join(" ")
+      # use parallel gzip for faster compression (uses all available CPU cores)
+      command << " | pigz - > '#{tarball_path}'"
       res = SCR.Execute(path(".target.bash_output"),  command)
       log.info "backup created with '#{command}' result: #{res}"
 

--- a/test/update_test.rb
+++ b/test/update_test.rb
@@ -70,7 +70,7 @@ describe Yast::Update do
     it "create tarball including given name with all paths added" do
       name = "test-backup"
       paths = ["a", "b"]
-      expect(Yast::SCR).to receive(:Execute).with(Yast::Path.new(".target.bash_output"), /^tar c.*#{name}.*tar.bz2.*a.*b/).
+      expect(Yast::SCR).to receive(:Execute).with(Yast::Path.new(".target.bash_output"), /^tar c.*a.*b.*#{name}.tar.gz/).
         and_return({"exit" => 0})
       Yast::Update.create_backup(name, paths)
     end
@@ -94,7 +94,7 @@ describe Yast::Update do
     it "change permission of tarball to be readable only for creator" do
       name = "test-backup"
       paths = ["a", "b"]
-      expect(::FileUtils).to receive(:chmod).with(0600, /test-backup\.tar.bz2/)
+      expect(::FileUtils).to receive(:chmod).with(0600, /test-backup\.tar.gz/)
 
       Yast::Update.create_backup(name, paths)
     end


### PR DESCRIPTION
- ... to prevent from accidental corruption
- switch from `bzip2` to `gzip` compression (slightly less compression
  ratio, but much faster), use parallel gzip (`pigz`) for even
  faster backup
- 3.1.21
### Notes
- `pigz` is included in SLE12 and it's used by `dracut` which is needed by `mkinitrd`, it's a core package and should be supported well
- I did some research about speed vs. backup size, see [the table](https://docs.google.com/spreadsheets/d/1g0pTSd_ZCnwBaUGKX4sRUc1URtfe49_Ay7eYRgcgDbs/edit?usp=sharing)
- tested in update from SLES11-SP3 (`pigz` was added to inst-sys by `dud=` option)
