### PR TITLE
Sort patterns in the upgrade summary (bsc#931295)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 18 14:42:15 UTC 2015 - lslezak@suse.cz
+
+- sort patterns in the upgrade summary to have stable output for
+  openQA tests (bsc#931295), escape the HTML tags
+- 3.1.28
+
+-------------------------------------------------------------------
 Mon Feb  9 16:18:41 UTC 2015 - lslezak@suse.cz
 
 - install the packages needed for accesing the installation

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        3.1.27
+Version:        3.1.28
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/update_proposal.rb
+++ b/src/clients/update_proposal.rb
@@ -25,7 +25,9 @@
 #
 # Purpose:	Let user choose update settings.
 #
-# $Id$
+
+require "cgi/util"
+
 module Yast
   class UpdateProposalClient < Client
     include Yast::Logger
@@ -209,14 +211,17 @@ module Yast
             "</li>\n"
           )
 
-          if @patterns != nil && Ops.greater_than(Builtins.size(@patterns), 0)
+          if @patterns != nil && !@patterns.empty?
             @summary_text = Ops.add(@summary_text, HTML.ListStart)
+
+            # sort the patterns
+            @patterns.sort! { |x, y| x["order"].to_i <=> y["order"].to_i }
 
             Builtins.foreach(@patterns) do |p|
               @summary_text = Ops.add(
                 Ops.add(
                   Ops.add(@summary_text, "<li>"),
-                  Ops.get_string(p, "summary", Ops.get_string(p, "name", ""))
+                  CGI.escapeHTML(Ops.get_string(p, "summary", Ops.get_string(p, "name", "")))
                 ),
                 "</li>\n"
               )


### PR DESCRIPTION
... to have stable output for openQA tests

- Escape the HTML tags
- 3.1.28