### PR TITLE
Do not select additional products when initializing the update proposal

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jan 29 09:37:57 UTC 2016 - lslezak@suse.cz
+
+- Fixed selecting additional products during system upgrade
+  (do not select previously unselected products after adding
+  repositories from the registration server) (bsc#959155)
+- 3.1.34.1
+
+-------------------------------------------------------------------
 Mon Oct  5 08:49:01 CEST 2015 - locilka@suse.com
 
 - Added new test for Update.IsProductSupportedForUpgrade

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        3.1.34
+Version:        3.1.34.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/update_proposal.rb
+++ b/src/clients/update_proposal.rb
@@ -474,10 +474,16 @@ module Yast
       if !Update.did_init1
         Update.did_init1 = true
 
+        # products to reselect after reset
         restore = []
-        selected = Pkg.ResolvableProperties("", :product, "")
-        Builtins.foreach(selected) do |s|
-          restore = Builtins.add(restore, Ops.get_string(s, "name", ""))
+
+        Pkg.ResolvableProperties("", :product, "").each do |product|
+          # only selected items but ignore the selections done by solver,
+          # during restoration they would be changed to be selected by YaST and they
+          # will be selected by solver again anyway
+          if product["status"] == :selected && product["transact_by"] != :solver
+            restore << product["name"]
+          end
         end
 
         Pkg.PkgApplReset

--- a/src/clients/update_proposal.rb
+++ b/src/clients/update_proposal.rb
@@ -528,6 +528,11 @@ module Yast
         Update.solve_errors = Pkg.PkgSolveErrors
       end
 
+      log.info "Update compatibility: " \
+        "Update.ProductsCompatible: #{Update.ProductsCompatible}, " \
+        "Update.products_incompatible: #{Update.products_incompatible}, " \
+        "update_not_possible: #{update_not_possible}"
+
       # check product compatibility
       if !(Update.ProductsCompatible || Update.products_incompatible) || update_not_possible
         if Popup.ContinueCancel(

--- a/src/modules/Update.rb
+++ b/src/modules/Update.rb
@@ -122,23 +122,20 @@ module Yast
     #-----------------------------------------------------------------------
 
     def ListOfRegexpsMatchesProduct(regexp_items, product)
-      regexp_items = deep_copy(regexp_items)
-      return false if regexp_items == nil || regexp_items == []
-      if product == nil
-        Builtins.y2error("Product is nil")
+      return false if regexp_items.nil? || regexp_items.empty?
+
+      if product.nil?
+        log.error "Product is nil"
         return false
       end
 
-      ret = false
-      Builtins.foreach(regexp_items) do |one_regexp|
-        if Builtins.regexpmatch(product, one_regexp)
-          Builtins.y2milestone(">%1< is matching >%2<", product, one_regexp)
-          ret = true
-          raise Break
-        end
+      ret = regexp_items.any? do |one_regexp|
+        match = Builtins.regexpmatch(product, one_regexp)
+        log.info ">#{product}< is matching >#{one_regexp}<" if match
+        match
       end
 
-      Builtins.y2milestone("Returning %1", ret)
+      log.info "A regexp matches the installed product: #{ret}"
       ret
     end
 


### PR DESCRIPTION
 The fix is similar to https://github.com/yast/yast-packager/pull/146, fixes [bug #959155](https://bugzilla.suse.com/show_bug.cgi?id=959155).

- Tested manually in a patched installer
- Added/fixed some logging
- Small Rubyfication

### Original Behavior

Some new products were selected for installation during upgrade:

![sles-sap-broken-upgrade](https://cloud.githubusercontent.com/assets/907998/12676656/2ed0b39c-c694-11e5-9cca-12e1fe3c192b.png)

### With the Fix Applied

With this fix applied no new product is selected:

![sles-sap-fixed-upgrade](https://cloud.githubusercontent.com/assets/907998/12676664/3e7df048-c694-11e5-886f-8589974479df.png)
