### PR TITLE
Update installer is called earlier. Data store is not needed anymore.

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Aug 26 08:54:40 UTC 2016 - kanderssen@suse.com
+
+- The update installer has been moved earlier in the workflow. We
+  don't need to store data to remember selected target/partitions
+  anymore. (bsc#988287)
+- 3.1.42
+
+-------------------------------------------------------------------
 Fri Aug  5 08:55:42 UTC 2016 - kanderssen@suse.com
 
 - Remember selected target/partitions after an installer update.

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        3.1.41
+Version:        3.1.42
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/update/clients/inst_update_partition_auto.rb
+++ b/src/lib/update/clients/inst_update_partition_auto.rb
@@ -76,8 +76,6 @@ module Yast
           UmountMountedPartition()
           Pkg.TargetFinish
         else
-          store_data
-
           return :next
         end
       end

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -15,6 +15,5 @@ module Helpers
     allow(subject).to receive(:target_distribution).and_return("sle-12-x86_64")
     allow(subject).to receive(:initialize_update_rootpart)
     allow(subject).to receive(:load_data)
-    allow(subject).to receive(:store_data)
   end
 end

--- a/test/inst_update_partition_auto_test.rb
+++ b/test/inst_update_partition_auto_test.rb
@@ -10,30 +10,16 @@ Yast.import "Installation"
 describe Yast::InstUpdatePartitionAutoClient do
 
   describe "#main" do
-    let(:restarting) { false }
-
     before do
       stub_root_part
       stub_const("Yast::FileSystems", double)
       allow(Yast::Update)
-      allow(Yast::Installation).to receive(:restarting?) { restarting }
       allow(Yast::Installation).to receive(:destdir).and_return("/mnt")
       allow(Yast::Report).to receive(:error)
       allow(Yast::Pkg).to receive(:TargetInitializeOptions)
       allow(Yast::Pkg).to receive(:TargetFinish)
       allow(Yast::Pkg).to receive(:TargetLoad).and_return(true)
       stub_subject(subject)
-    end
-
-    context "when installation is restarting" do
-      let(:restarting) { true }
-
-      it "loads data if it was stored" do
-        expect(subject).to receive(:data_stored?).and_return(true)
-        expect(subject).to receive(:load_data)
-
-        subject.main
-      end
     end
 
     context "when root partition is mounted" do
@@ -117,7 +103,6 @@ describe Yast::InstUpdatePartitionAutoClient do
       context "when the target system is mounted successfully" do
         before do
           allow(Yast::RootPart).to receive(:mount_target).and_return(true)
-          allow(subject).to receive(:store_data)
         end
 
         context "when it detects an incomplete installation" do
@@ -174,13 +159,6 @@ describe Yast::InstUpdatePartitionAutoClient do
             allow(Yast::Pkg).to receive(:TargetInitializeOptions).and_return(true)
           end
 
-          it "saves current data" do
-            expect(subject).not_to receive(:RootPartitionDialog)
-            expect(subject).to receive(:store_data)
-
-            subject.main
-          end
-
           it "returns :next without shown selection dialog" do
             expect(subject).not_to receive(:RootPartitionDialog)
 
@@ -195,12 +173,6 @@ describe Yast::InstUpdatePartitionAutoClient do
       before do
         allow(subject).to receive(:RootPartitionDialog).and_return(:next)
         allow(subject).to receive(:target_system_candidate).and_return(nil)
-      end
-
-      it "stores current data" do
-        expect(subject).to receive(:store_data)
-
-        subject.main
       end
 
       it "returns :next" do


### PR DESCRIPTION
This PR is part of the [self update refactorization](https://github.com/yast/yast-installation/pull/422), as the update installer client will be called earlier in the workflow previous fixes are not needed.