### PR TITLE
Fixed parsing whitespace lines in the original /etc/fstab (bsc#1030425)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,8 @@ stamp-h*
 update.pot
 Makefile.am.common
 *.ami
-doc/autodocs/*.html
+doc
+.yardoc
 /test-driver
 /test/*.log
 /test/*.trs

--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 19 14:38:34 UTC 2017 - lslezak@suse.cz
+
+- Fixed parsing whitespace lines in the original /etc/fstab
+  (bsc#1030425)
+- 3.2.2
+
+-------------------------------------------------------------------
 Mon Jan 30 12:07:55 UTC 2017 - igonzalezsosa@suse.com
 
 - Allow YaST modules to add packages during upgrade (bsc#1009834)

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        3.2.1
+Version:        3.2.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -809,6 +809,8 @@ module Yast
       fstab_file = Ops.add(Installation.destdir, "/etc/fstab")
 
       if FileUtils.Exists(fstab_file)
+        # Note: this is a copy from etc_fstab.scr file (yast2.rpm),
+        # keep the files in sync!
         SCR.RegisterAgent(
           path(".target.etc.fstab"),
           term(
@@ -816,7 +818,8 @@ module Yast
             term(
               :Description,
               term(:File, fstab_file),
-              "#\n", # Comment
+              # tab and space is a workaround for white space only lines (bsc#1030425)
+              "#\n\t ",	# Comment
               false, # read-only
               term(
                 :List,


### PR DESCRIPTION
- 3.2.2

This is the same fix as in https://github.com/yast/yast-yast2/pull/570.