### PR TITLE
Drop support of reiserfs in a system upgrade (fate#323394)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # YaST - The Update Module #
 
+[![Coverage
+Status](https://coveralls.io/repos/github/yast/yast-update/badge.svg?branch=master)](https://coveralls.io/github/yast/yast-update?branch=master)
 [![Travis Build](https://travis-ci.org/yast/yast-update.svg?branch=master)](https://travis-ci.org/yast/yast-update)
 [![Jenkins Build](http://img.shields.io/jenkins/s/https/ci.opensuse.org/yast-update-master.svg)](https://ci.opensuse.org/view/Yast/job/yast-update-master/)
 

--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 16 11:44:44 UTC 2017 - knut.anderssen@suse.com
+
+- Do not allow to upgrade if the target system uses reiserfs
+  (fate#323394).
+- 3.3.1
+
+-------------------------------------------------------------------
 Mon Aug 14 10:22:00 UTC 2017 - ancor@suse.com
 
 - Merged storage-ng branch (fate#318196).

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        3.3.0
+Version:        3.3.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -361,12 +361,12 @@ module Yast
             freshman
           )
 
+          # Removed ReiserFS support for system upgrade (fate#323394).
           if freshman[:fs] == :reiserfs
             cont = false
             Report.Error(_("ReiserFS is not supported anymore.\n" \
-                            "Please migrate your data to other " \
-                            "filesystem before performing the upgrade.\n\n" \
-                            "More details can be found in the release notes."))
+                            "Please migrate your data to another " \
+                            "filesystem before performing the upgrade.\n\n"))
           elsif (freshman[:name] || "unknown") == "unknown"
             cont = false
             Popup.Error(

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -363,11 +363,11 @@ module Yast
 
           if freshman[:fs] == :reiserfs
             cont = false
-            Report.Error(_("Reiserfs is not supported anymore.\n" \
+            Report.Error(_("ReiserFS is not supported anymore.\n" \
                             "Please migrate your data to other " \
-                            "filesystem before perform the upgrade.\n\n" \
+                            "filesystem before performing the upgrade.\n\n" \
                             "More details can be found in the release notes."))
-          elsif Ops.get_string(freshman, :name, "unknown") == "unknown"
+          elsif (freshman[:name] || "unknown") == "unknown"
             cont = false
             Popup.Error(
               # error popup

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -368,6 +368,13 @@ module Yast
                 "No installed system that can be upgraded with this product was found\non the selected partition."
               )
             )
+          elsif freshman[:fs] == :reiserfs
+            cont = false
+            Report.Error(_("Reiserfs is not supported anymore.\n" \
+                            "Please migrate your data to other " \
+                            "filesystem before perform the upgrade.\n\n" \
+                            "More details can be found in the release notes."))
+
           elsif !DoArchitecturesMatch(
               Ops.get_string(freshman, :arch, ""),
               RootPart.GetDistroArch
@@ -397,7 +404,7 @@ module Yast
               # error report
               Report.Error(_("Failed to mount target system"))
               UmountMountedPartition()
-              next 
+              next
 
               # Correctly mounted but incomplete installation found
             elsif RootPart.IncompleteInstallationDetected(Installation.destdir)

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -360,7 +360,14 @@ module Yast
             selected,
             freshman
           )
-          if Ops.get_string(freshman, :name, "unknown") == "unknown"
+
+          if freshman[:fs] == :reiserfs
+            cont = false
+            Report.Error(_("Reiserfs is not supported anymore.\n" \
+                            "Please migrate your data to other " \
+                            "filesystem before perform the upgrade.\n\n" \
+                            "More details can be found in the release notes."))
+          elsif Ops.get_string(freshman, :name, "unknown") == "unknown"
             cont = false
             Popup.Error(
               # error popup
@@ -368,13 +375,6 @@ module Yast
                 "No installed system that can be upgraded with this product was found\non the selected partition."
               )
             )
-          elsif freshman[:fs] == :reiserfs
-            cont = false
-            Report.Error(_("Reiserfs is not supported anymore.\n" \
-                            "Please migrate your data to other " \
-                            "filesystem before perform the upgrade.\n\n" \
-                            "More details can be found in the release notes."))
-
           elsif !DoArchitecturesMatch(
               Ops.get_string(freshman, :arch, ""),
               RootPart.GetDistroArch

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1589,7 +1589,6 @@ module Yast
       MountVarPartition(var_partition_current)
     end
 
-
     # Mounting root-partition; reading fstab and mounting read partitions
     def MountPartitions(root_device_current)
       Builtins.y2milestone("mount partitions: %1", root_device_current)
@@ -1714,14 +1713,18 @@ module Yast
 
               Builtins.y2milestone("fstab %1", fstab)
 
-              reiserfs_entries = fstab.select { |e| e["vfstype"].include? "reiser" }
+              reiserfs_entries =
+                fstab.select { |e| e["vfstype"] == Y2Storage::Filesystems::Type::REISERFS.to_s }
 
+              # Removed ReiserFS support for system upgrade (fate#323394).
               if !reiserfs_entries.empty?
                 message =
                   Builtins.sformat(
-                    _("The mount points listed below are using ReiserFS that is not supported anymore:\n\n%1\n\n" \
-                      "Before upgrade you should migrate all your data to other filesystem.\n" \
-                      "More details can be found in the release notes."),
+                    _("The mount points listed below are using ReiserFS that " \
+                      "is not supported anymore:\n\n%1\n\n"                    \
+                      "Before upgrade you should migrate all "                 \
+                      "your data to another filesystem.\n"
+                    ),
                     reiserfs_entries.map { |e| e["file"] }.join("\n")
                   )
 

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1714,16 +1714,15 @@ module Yast
 
               Builtins.y2milestone("fstab %1", fstab)
 
-              if reiserfs_in_fstab?(fstab)
-                reiserfs_entries = fstab.find_all {|e| e["vfstype"].include? "reiser" }
-                mount_points = reiserfs_entries.map {|e| e["file"] }.join("\n")
+              reiserfs_entries = fstab.select { |e| e["vfstype"].include? "reiser" }
 
+              if !reiserfs_entries.empty?
                 message =
                   Builtins.sformat(
-                    _("The mount points listed below are using reiserfs that is not supported anymore:\n\n%1\n\n" \
+                    _("The mount points listed below are using ReiserFS that is not supported anymore:\n\n%1\n\n" \
                       "Before upgrade you should migrate all your data to other filesystem.\n" \
                       "More details can be found in the release notes."),
-                    mount_points
+                    reiserfs_entries.map { |e| e["file"] }.join("\n")
                   )
 
                 success = false
@@ -2202,10 +2201,6 @@ module Yast
       log.warning("Device does not match fstab: #{device} vs. #{value}") unless matches
 
       matches
-    end
-
-    def reiserfs_in_fstab?(fstab)
-      fstab.any? { |e| e["vfstype"].include? "reiser"}
     end
 
     def update_staging!

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -265,8 +265,10 @@ module Yast
 
       # now remove the mount points of the mounted partitions
       # in the target map of the storage module
-      #  RemoveFromTargetMap() if !keep_in_target
       #
+      # RemoveFromTargetMap() if !keep_in_target
+      #
+      # storage-ng
       staging.filesystems.map { |f| f.mountpoint = nil } if !keep_in_target
 
       # clear activated list

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,3 +9,24 @@ RSpec.configure do |config|
   config.include Yast::I18n # available in it/let/before
   config.include Helpers
 end
+
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/test/"
+  end
+
+  src_location = File.expand_path("../../src", __FILE__)
+  # track all ruby files under src
+  SimpleCov.track_files("#{src_location}/**/*.rb")
+
+  # use coveralls for on-line code coverage reporting at Travis CI
+  if ENV["TRAVIS"]
+    require "coveralls"
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+    ]
+  end
+end
+


### PR DESCRIPTION
- trello card: https://trello.com/c/V3v4093v/1014-3-reiserfs-is-dead-manual-upgrade

![screenshot from 2017-08-16 14-02-23](https://user-images.githubusercontent.com/7056681/29366627-702c5696-8292-11e7-986f-8b25684a9221.png)
### Selected root partition with reiserfs
![screenshot from 2017-08-17 09-38-34](https://user-images.githubusercontent.com/7056681/29403335-f377128c-832f-11e7-8dd9-77d4f692bda3.png)


### Some fstab entry with reiserfs filesystem

![screenshot from 2017-08-17 09-38-16](https://user-images.githubusercontent.com/7056681/29403336-f5ef791e-832f-11e7-89e8-2297201078f3.png)


