### PR TITLE
Show legacy(fate#323394)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Tue Aug 22 10:59:42 UTC 2017 - knut.anderssen@suse.com
 
-- Show also legacy root filesystems in the selectable list for
-  update from(fate#323394)
+- Show legacy root filesystems in the list of systems to upgrade
+  from (fate#323394).
 - 3.3.4
 
 -------------------------------------------------------------------

--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 22 10:59:42 UTC 2017 - knut.anderssen@suse.com
+
+- Show also legacy root filesystems in the selectable list for
+  update from(fate#323394)
+- 3.3.4
+
+-------------------------------------------------------------------
 Mon Aug 21 10:14:50 UTC 2017 - ancor@suse.com
 
 - Use translatable and human-friendly format to display the

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        3.3.3
+Version:        3.3.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -41,9 +41,9 @@ BuildRequires:	yast2-installation-control
 # Needed for tests
 BuildRequires:  rubygem(rspec)
 
-BuildRequires:	yast2-storage-ng >= 0.1.32
-# New versions of StorageManager#probed and StorageManager#staging
-Requires:	yast2-storage-ng >= 0.1.32
+BuildRequires:	yast2-storage-ng >= 3.3.4
+# Legacy root filesystems methods
+Requires:	yast2-storage-ng >= 3.3.4
 # FSSnapshotStore
 Requires:	yast2 >= 3.1.126
 Requires:	yast2-installation


### PR DESCRIPTION
Because of this PR yast/yast-storage-ng#335 the partitions using ReiserFS was not shown by default and also shown as a not known linux / Unix partition.

So we have added support for legacy root filesystems in yast/yast-storage-ng#340 and also with this PR the information about the filesystem will be shown in the list although we will block the upgrade if selected and next is pressed (during mount will be detected the presence of legacy filesystems in the fstab)

An autoupgrade will select the only selectable root partition but will detect the presence of legacy root filesystems in the fstab and will show this error:


![screenshot_sles12sp3_2017-08-22_11 54 39](https://user-images.githubusercontent.com/7056681/29562882-1fb6afd6-8733-11e7-9d04-38af9a5ad704.png)

There will be other error about not able to mount the target system and then the list of selectable partitions will show all the information about the failed one:

![screenshot_sles12sp3_2017-08-22_11 56 49](https://user-images.githubusercontent.com/7056681/29562920-494b4316-8733-11e7-8cd3-c2525c98feaf.png)
