### PR TITLE
Check by udev names discarded by libstorage-ng (bsc#1073254) 

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 19 17:27:41 UTC 2017 - ancor@suse.com
+
+- When matching partitions, also use udev names that have been
+  discarded by libstorage-ng (bsc#1073254).
+- 4.0.3
+
+-------------------------------------------------------------------
 Mon Dec 18 16:32:10 UTC 2017 - ancor@suse.com
 
 - Use udev names, in addition to kernel device names, to match

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.0.2
+Version:        4.0.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -42,8 +42,8 @@ BuildRequires:	yast2-installation-control
 BuildRequires:  rubygem(rspec)
 
 BuildRequires:	yast2-storage-ng >= 3.3.4
-# Legacy root filesystems methods
-Requires:	yast2-storage-ng >= 3.3.4
+# Y2Storage::BlkDevice.find_by_any_name
+Requires:	yast2-storage-ng >= 4.0.59
 # FSSnapshotStore
 Requires:	yast2 >= 3.1.126
 Requires:	yast2-installation


### PR DESCRIPTION
This is part of https://trello.com/c/lOQcX484/806-bug-1073254-storage-ng-staginge-fails-to-test-upgrade-a-131-installation-to-tw

Depends on this other PR being merged before: https://github.com/yast/yast-storage-ng/pull/473