### PR TITLE
Use the new Devicegraph#find_by_any_name

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan  9 07:09:57 UTC 2018 - ancor@suse.com
+
+- When matching partitions, rely on the new
+  Y2Storage::Devicegraph#find_by_any_name (bsc#1073254).
+- 4.0.5
+
+-------------------------------------------------------------------
 Fri Jan  5 07:33:52 UTC 2018 - jsrain@suse.cz
 
 - upgrade the system always via equivalent of 'zypper dup'

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.0.4
+Version:        4.0.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -42,8 +42,8 @@ BuildRequires:	yast2-installation-control
 BuildRequires:  rubygem(rspec)
 
 BuildRequires:	yast2-storage-ng >= 3.3.4
-# Y2Storage::BlkDevice.find_by_any_name
-Requires:	yast2-storage-ng >= 4.0.59
+# Y2Storage::Devicegraph#find_by_any_name
+Requires:	yast2-storage-ng >= 4.0.67
 # FSSnapshotStore
 Requires:	yast2 >= 3.1.126
 Requires:	yast2-installation

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -2204,14 +2204,7 @@ module Yast
     # @param blk_dev [Y2Storage::BlkDevice]
     # @return [Boolean]
     def name_matches_device?(name, blk_dev)
-      # First try the cheapest alternative: matching against the names directly
-      # handled by libstorage-ng
-      known_dev_names = [blk_dev.name] + blk_dev.udev_full_all
-      return true if known_dev_names.include?(name)
-
-      # If the previous didn't match, there is still a chance using the slower
-      # .find_by_any_name in the probed devicegraph
-      found = Y2Storage::BlkDevice.find_by_any_name(probed, name)
+      found = staging.find_by_any_name(name)
       return true if found && found.sid == blk_dev.sid
 
       log.warn("Device does not match fstab (name): #{blk_dev.name} not equivalent to #{name}")


### PR DESCRIPTION
See https://bugzilla.suse.com/show_bug.cgi?id=1073254

Based on https://github.com/yast/yast-storage-ng/pull/479

I manually tested the 13.1 -> TW upgrade including the three patches (this, https://github.com/yast/yast-storage-ng/pull/479 and https://github.com/yast/yast-bootloader/pull/476) and it worked. :+1: