### PR TITLE
Automatically save a solver test case (related to bsc#1084248)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  8 09:25:38 UTC 2018 - lslezak@suse.cz
+
+- Automatically save a solver test case when the product summary
+  contains a warning for easier debugging (related to bsc#1084248)
+- 4.0.10
+
+-------------------------------------------------------------------
 Fri Feb  9 14:52:57 UTC 2018 - jlopez@suse.com
 
 - Adapt to new MountPoint API (part of fate#318196).

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.0.9
+Version:        4.0.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/packages_proposal.rb
+++ b/src/clients/packages_proposal.rb
@@ -86,7 +86,7 @@ module Yast
           @cnt_installed,
           @cnt_removed
         )
-        Builtins.y2milestone("Removed: %1", @removed)
+        log.info("Removed packages: #{@removed.sort}")
 
         @installed_m = Builtins.listmap(@installed) { |p| { p => true } }
         @selected_m = Builtins.listmap(@selected) { |p| { p => true } }

--- a/src/clients/update_proposal.rb
+++ b/src/clients/update_proposal.rb
@@ -213,6 +213,8 @@ module Yast
           @ret["warning"] = @warning_message
           @ret["warning_level"] = product_warning["warning_level"] || :warning
         end
+        # save the solver test case with details for later debugging
+        Pkg.CreateSolverTestCase("/var/log/YaST2/solver-upgrade-proposal") if @ret["warning"]
       elsif @func == "AskUser"
 	# With proper control file, this should never be reached
         Report.Error(_("The update summary is read only and cannot be changed."))


### PR DESCRIPTION
When the product summary contains a warning save the solver test case for easier debugging. It will be included in the logs collected by `save_y2logs` script.

- See https://bugzilla.suse.com/show_bug.cgi?id=1084248
- 4.0.10