### PR TITLE
Fixed rollback (bsc#1089643)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Fri Apr 27 13:45:41 UTC 2018 - lslezak@suse.cz
 
-- Copy the resolv.conf and the device files from inst-sys
-  to target, sort the restore scripts to run them in the expected
+- Copy the resolv.conf and bind mount /dev directory to the target
+  root, sort the restore scripts to run them in the expected
   order (bsc#1089643)
 - 4.0.13
 

--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Apr 27 13:45:41 UTC 2018 - lslezak@suse.cz
+
+- Copy the resolv.conf and the device files from inst-sys
+  to target, sort the restore scripts to run them in the expected
+  order (bsc#1089643)
+- 4.0.13
+
+-------------------------------------------------------------------
 Mon Mar 19 16:24:35 UTC 2018 - ancor@suse.com
 
 - Fixed a crash when upgrading systems with a separate /var

--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -4,6 +4,8 @@ Fri Apr 27 13:45:41 UTC 2018 - lslezak@suse.cz
 - Copy the resolv.conf and bind mount /dev directory to the target
   root, sort the restore scripts to run them in the expected
   order (bsc#1089643)
+- The bind mount also fixes the libzypp plugin service refresh
+  (bsc#1080693)
 - 4.0.13
 
 -------------------------------------------------------------------

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -49,8 +49,8 @@ Requires:	yast2-storage-ng >= 4.0.137
 Requires:	yast2 >= 3.1.126
 Requires:	yast2-installation
 
-# Packages#proposal_for_update
-Requires:	yast2-packager >= 3.2.13
+# handle bind mount at /mnt/dev
+Requires:	yast2-packager >= 4.0.61
 
 # Pkg.TargetInitializeOptions()
 Requires:       yast2-pkg-bindings >= 3.1.14

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.0.12
+Version:        4.0.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1702,9 +1702,6 @@ module Yast
       ]
     }
 
-    # copy these device files into inst-sys to make sure the chrooted scripts work
-    REQUIRED_DEVICES = [ "null", "zero", "random", "urandom" ]
-
     def create_backup
       BACKUP_DIRS.each_pair do |name, paths|
         Update.create_backup(name, paths)
@@ -1717,11 +1714,9 @@ module Yast
       # the original file is backed up and restored later
       ::FileUtils.cp(RESOLV_CONF, File.join(Installation.destdir, RESOLV_CONF)) if File.exist?(RESOLV_CONF)
 
-      REQUIRED_DEVICES.each do |dev|
-        # FileUtils.cp does not handle device files correctly, use `cp -a` instead
-        target = File.join(Installation.destdir, "dev", dev)
-        system("cp -a /dev/#{dev} #{Shellwords.escape(target)}")
-      end
+      # make the /dev files available in the chroot so the scripts work correctly there
+      target = File.join(Installation.destdir, "dev")
+      system("mount --bind /dev #{Shellwords.escape(target)}")
     end
 
     # Get architecture of an elf file.

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -31,6 +31,8 @@ require "yast2/fs_snapshot"
 require "yast2/fs_snapshot_store"
 require "y2storage"
 
+require "fileutils"
+
 module Yast
   class RootPartClass < Module
     include Logger
@@ -1675,24 +1677,50 @@ module Yast
         end
         Update.clean_backup
         create_backup
+        inject_intsys_files
       end
 
       success
     end
 
+    RESOLV_CONF = "/etc/resolv.conf".freeze
+
     # known configuration files that are changed during update, so we need to
     # backup them to restore if something goes wrong (bnc#882039)
     BACKUP_DIRS = {
-      "sw_mgmt" => [
+      # use a number prefix to set the execution order
+      "0100-sw_mgmt" => [
         "/var/lib/rpm",
         "/etc/zypp/repos.d",
         "/etc/zypp/services.d",
         "/etc/zypp/credentials.d"
+      ],
+      # this should be restored as the very last one, after restoring the original
+      # resolv.conf the network might not work properly in the chroot
+      "0999-resolv_conf" => [
+        RESOLV_CONF
       ]
     }
+
+    # copy these device files into inst-sys to make sure the chrooted scripts work
+    REQUIRED_DEVICES = [ "null", "zero", "random", "urandom" ]
+
     def create_backup
       BACKUP_DIRS.each_pair do |name, paths|
         Update.create_backup(name, paths)
+      end
+    end
+
+    # inject the required files from the inst-sys to the chroot so
+    # the network connection works for the chrooted scripts
+    def inject_intsys_files
+      # the original file is backed up and restored later
+      ::FileUtils.cp(RESOLV_CONF, File.join(Installation.destdir, RESOLV_CONF)) if File.exist?(RESOLV_CONF)
+
+      REQUIRED_DEVICES.each do |dev|
+        # FileUtils.cp does not handle device files correctly, use `cp -a` instead
+        target = File.join(Installation.destdir, "dev", dev)
+        system("cp -a /dev/#{dev} #{Shellwords.escape(target)}")
       end
     end
 

--- a/src/modules/Update.rb
+++ b/src/modules/Update.rb
@@ -775,11 +775,12 @@ module Yast
     BACKUP_DIR = "var/adm/backup/system-upgrade"
     # Creates backup with name based on `name` contaings everything
     # matching globs in `paths`.
-    # @param name[String] name for backup file. Use bash friendly name ;)
+    # @param name[String] name for backup file. Use a number prefix to run
+    #   the restore scripts in the expected order. Use a bash friendly name ;)
     # @note Can be called only after target root is mounted.
     #
     # @example to store repos file and credentials directory
-    #   Update.create_backup("repos", ["/etc/zypp/repos.d/*", "/etc/zypp/credentials"])
+    #   Update.create_backup("0100-repos", ["/etc/zypp/repos.d/*", "/etc/zypp/credentials"])
     def create_backup(name, paths)
       log.info "Creating tarball for #{name} including #{paths}"
       mounted_root = Installation.destdir
@@ -805,7 +806,8 @@ module Yast
       log.info "Restoring backup"
       mounted_root = Installation.destdir
       script_glob = File.join(mounted_root, BACKUP_DIR,"restore-*.sh")
-      ::Dir.glob(script_glob).each do |path|
+      # sort the scripts to execute them in the expected order
+      ::Dir.glob(script_glob).sort.each do |path|
         cmd = "sh #{path} #{File.join("/", mounted_root)}"
         res = SCR.Execute(path(".target.bash_output"), cmd)
         log.info "Restoring with script #{cmd} result: #{res}"


### PR DESCRIPTION
- Sort the restore scripts alphabetically
- Inject resolv.conf and bind mount the `/dev` to the target chroot so network and the SSL communication with the SCC server works (`/dev/urandom` is need for the encryption).