### PR TITLE
Fixed /mnt/dev unmount

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May  9 10:20:03 UTC 2018 - lslezak@suse.cz
+
+- Fixed unmounting /mnt/dev when going back to the partition
+  selection dialog (fix up for the bsc#1089643)
+- 4.0.14
+
+-------------------------------------------------------------------
 Fri Apr 27 13:45:41 UTC 2018 - lslezak@suse.cz
 
 - Copy the resolv.conf and bind mount /dev directory to the target

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.0.13
+Version:        4.0.14
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/root_part_test.rb
+++ b/test/root_part_test.rb
@@ -234,4 +234,18 @@ describe Yast::RootPart do
       end
     end
   end
+
+  describe "#MountFSTab" do
+    it "mounts /dev, /proc and /sys" do
+      allow(subject).to receive(:AddMountedPartition)
+
+      ["/dev", "/proc", "/sys"].each do |d|
+        expect(subject).to receive(:MountPartition).with(d, anything, anything)
+      end
+
+      # call with empty list to only test the /dev, /proc and /sys mounting
+      fstab = []
+      subject.MountFSTab(fstab, "")
+    end
+  end
 end


### PR DESCRIPTION
## Bug

When going back in the upgrade workflow back to the partition selection this error was displayed: ![failed_unmount](https://user-images.githubusercontent.com/907998/39810591-d61d85f0-5385-11e8-8dcb-dc86ed19fc1c.png)

The problem was caused by not unmounting `/mnt/dev`

## Fix

- This was caused by previous #97 which did not unmount `/mnt/dev` when going back
- Use the same solution as already used for the `/proc` and `/sys` directories (see the diff above the added `MountPartition` call)
- The `AddMountedPartition` remembers the mounted directory and unmounts it when going back
- Tested manually