### PR TITLE
Flush the disk cache after restoring the backup (bsc#1089643)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jun  6 11:19:12 UTC 2018 - lslezak@suse.cz
+
+- Flush the disk cache after restoring the backup to mitigate
+  risk of data loss after unexpected reboot/poweroff after aborting
+  upgrade (bsc#1089643)
+- 4.0.15
+
+-------------------------------------------------------------------
 Wed May  9 10:20:03 UTC 2018 - lslezak@suse.cz
 
 - Fixed unmounting /mnt/dev when going back to the partition

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.0.14
+Version:        4.0.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Update.rb
+++ b/src/modules/Update.rb
@@ -891,6 +891,10 @@ cd ${1:-/}
 tar xvf #{tarball_path} --overwrite
 # return back to original dir
 cd -
+# flush the caches
+sync
+# wait a bit to really write everything to disk (see "man sync")
+sleep 3
 EOF
 
       File.write(script_path, script_content)


### PR DESCRIPTION
- To mitigate risk of data loss after unexpected reboot/poweroff after aborting upgrade
- See https://bugzilla.suse.com/show_bug.cgi?id=1089643#c60
- 4.0.15