### PR TITLE
Update encryption names according to crypttab file

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun  7 17:10:49 UTC 2018 - jlopez@suse.com
+
+- Update encryption device names according to the values in the
+  crypttab file (bsc#1094963).
+- 4.0.16
+
+-------------------------------------------------------------------
 Wed Jun  6 11:19:12 UTC 2018 - lslezak@suse.cz
 
 - Flush the disk cache after restoring the backup to mitigate

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.0.15
+Version:        4.0.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -41,10 +41,10 @@ BuildRequires:	yast2-installation-control
 # Needed for tests
 BuildRequires:  rubygem(rspec)
 
-# Filesystems::Base#match_fstab_spec? and Filesystems::MountByType.from_fstab_spec
-BuildRequires:	yast2-storage-ng >= 4.0.137
-# Filesystems::Base#match_fstab_spec? and Filesystems::MountByType.from_fstab_spec
-Requires:	yast2-storage-ng >= 4.0.137
+# Encryption.use_crypttab_names
+BuildRequires:	yast2-storage-ng >= 4.0.186
+# Encryption.use_crypttab_names
+Requires:	yast2-storage-ng >= 4.0.186
 # FSSnapshotStore
 Requires:	yast2 >= 3.1.126
 Requires:	yast2-installation

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1530,12 +1530,11 @@ module Yast
         read_fstab_and_cryptotab(fstab_ref, crtab_ref, root_device_current)
         fstab = fstab_ref.value
         crtab = crtab_ref.value
-        # storage-ng
-=begin
-        Storage.ChangeDmNamesFromCrypttab(
-          Ops.add(Installation.destdir, "/etc/crypttab")
-        )
-=end
+
+        # Update encryption devices with the names indicated in the crypttab file (bsc#1094963)
+        crypttab_path = File.join(Installation.destdir, "/etc/crypttab")
+        Y2Storage::Encryption.use_crypttab_names(probed, crypttab_path)
+
         Update.GetProductName
 
         if FstabUsesKernelDeviceNameForHarddisks(fstab)


### PR DESCRIPTION
PBI: https://trello.com/c/OGssTRzO/393-osdistribution-p2p1-1094963-opensuse-150-installation-or-upgrade-fails-if-disk-contains-encrypted-partition-luks

It requires [this PR](https://github.com/yast/yast-storage-ng/pull/659) be merged. 