### PR TITLE
Do not crash when /etc/resolv.conf is immutable (bsc#1096142)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 12 15:13:58 UTC 2018 - lslezak@suse.cz
+
+- Do not crash at upgrade when the original /etc/resolv.conf
+  file is set to immutable (bsc#1096142)
+- 4.1.0
+
+-------------------------------------------------------------------
 Thu Jun  7 17:10:49 UTC 2018 - jlopez@suse.com
 
 - Update encryption device names according to the values in the

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.0.16
+Version:        4.1.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1718,7 +1718,13 @@ module Yast
     # the network connection works for the chrooted scripts
     def inject_intsys_files
       # the original file is backed up and restored later
-      ::FileUtils.cp(RESOLV_CONF, File.join(Installation.destdir, RESOLV_CONF)) if File.exist?(RESOLV_CONF)
+      target = File.join(Installation.destdir, RESOLV_CONF)
+      ::FileUtils.cp(RESOLV_CONF, target) if File.exist?(RESOLV_CONF)
+    rescue Errno::EPERM => e
+      # just log a warning when rewriting the file is not permitted,
+      # e.g. it has the immutable flag set (bsc#1096142)
+      # assume that the user locked content works properly
+      log.warn("Cannot update #{target}, keeping the original content, #{e.class}: #{e}")
     end
 
     # Get architecture of an elf file.


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1096142
- According to the reporter the system was gradually upgraded from 42.2 and uses some non-default settings (OpenDNS servers) so the bug should not affect many users => master should be enough
- 4.1.0