### PR TITLE
 Do not restore old backups when the upgrade fails

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 17 12:20:58 UTC 2018 - dgonzalez@suse.com
+
+- Avoid to restore old backups when upgrade fails (bsc#1097297)
+- 4.1.3
+
+-------------------------------------------------------------------
 Tue Sep 11 15:34:53 CEST 2018 - aschnell@suse.com
 
 - do not translate snapshot description (bsc#1092757)

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.1.2
+Version:        4.1.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Update.rb
+++ b/src/modules/Update.rb
@@ -285,7 +285,7 @@ module Yast
               found = Builtins.find(to_install) { |u| u == i }
               found != nil
             end
-            @_products_compatible = equal_product != nil 
+            @_products_compatible = equal_product != nil
             # no product name found
             # bugzilla #218720, valid without testing according to comment #10
           else
@@ -430,7 +430,7 @@ module Yast
 
       # Remove 'Beta...' from product release
       if Builtins.regexpmatch(old_name, "Beta")
-        old_name = Builtins.regexpsub(old_name, "^(.*)[ \t]+Beta.*$", "\\1") 
+        old_name = Builtins.regexpsub(old_name, "^(.*)[ \t]+Beta.*$", "\\1")
         # Remove 'Alpha...' from product release
       elsif Builtins.regexpmatch(old_name, "Alpha")
         old_name = Builtins.regexpsub(old_name, "^(.*)[ \t]+Alpha.*$", "\\1")
@@ -467,7 +467,7 @@ module Yast
             Installation.installedVersion,
             "major",
             Builtins.tointeger(inst_ver)
-          ) 
+          )
           # openSUSE
         elsif Builtins.regexpmatch(inst_ver, "^[0123456789]+.[0123456789]+$")
           Ops.set(
@@ -550,7 +550,7 @@ module Yast
             Ops.subtract(num, 1),
             0
           )
-        end 
+        end
         # default for !Stage::normal
       else
         update_to_source = Packages.GetBaseSourceID
@@ -624,7 +624,7 @@ module Yast
             Installation.updateVersion,
             "major",
             Builtins.tointeger(new_ver)
-          ) 
+          )
           # openSUSE
         elsif Builtins.regexpmatch(new_ver, "^[0123456789]+.[0123456789]$")
           Ops.set(

--- a/test/data/etc/leap-15-os-release
+++ b/test/data/etc/leap-15-os-release
@@ -1,0 +1,11 @@
+NAME="openSUSE Leap"
+VERSION="15.0"
+ID="opensuse-leap"
+ID_LIKE="suse opensuse"
+VERSION_ID="15.0"
+PRETTY_NAME="openSUSE Leap 15.0"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:leap:15.0"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"
+

--- a/test/data/etc/tw-os-release
+++ b/test/data/etc/tw-os-release
@@ -1,0 +1,11 @@
+NAME="openSUSE Tumbleweed"
+VERSION="20180911"
+ID="opensuse-tumbleweed"
+ID_LIKE="opensuse suse"
+VERSION_ID="20180911"
+PRETTY_NAME="openSUSE Tumbleweed"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:tumbleweed:20180911"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"
+

--- a/test/update_test.rb
+++ b/test/update_test.rb
@@ -151,17 +151,63 @@ describe Yast::Update do
   end
 
   describe "#restore_backup" do
-    it "call all restore scripts in backup directory" do
-      expect(::Dir).to receive(:glob).and_return(["restore-a.sh", "restore-b.sh"])
-      expect(Yast::SCR).to receive(:Execute).with(Yast::Path.new(".target.bash_output"), /sh .*restore-a.sh \/mnt/).
-        and_return({"exit" => 0})
-      expect(Yast::SCR).to receive(:Execute).with(Yast::Path.new(".target.bash_output"), /sh .*restore-b.sh \/mnt/).
-        and_return({"exit" => 0})
+    let(:os_release_pathname) { double }
+    let(:os_backup_release_pathname) { double }
+    let(:os_release_content) { File.new("#{DATA_DIR}/etc/leap-15-os-release").read }
+    let(:os_backup_release_content) { File.new("#{DATA_DIR}/etc/tw-os-release").read }
+
+    before do
+      allow(::Dir).to receive(:glob).and_return(["restore-a.sh", "restore-b.sh"])
+
+      allow(Pathname).to receive(:new)
+        .with("#{Yast::Installation.destdir}/etc/os-release")
+        .and_return(os_release_pathname)
+      allow(Pathname).to receive(:new)
+        .with("#{Yast::Installation.destdir}/#{Yast::UpdateClass::BACKUP_DIR}/os-release")
+        .and_return(os_backup_release_pathname)
+      allow(os_release_pathname).to receive(:read).and_return(os_release_content)
+      allow(os_backup_release_pathname).to receive(:read).and_return(os_backup_release_content)
+    end
+
+    it "check the release info files" do
+      expect(Pathname).to receive(:new)
+        .with("#{Yast::Installation.destdir}/etc/os-release")
+      expect(Pathname).to receive(:new)
+        .with("#{Yast::Installation.destdir}/#{Yast::UpdateClass::BACKUP_DIR}/os-release")
 
       Yast::Update.restore_backup
     end
-  end
 
+    context "when the release info match" do
+      let(:os_backup_release_content) { os_release_content }
+
+      it "call all restore scripts in backup directory" do
+        expect(Yast::SCR).to receive(:Execute)
+          .with(Yast::Path.new(".target.bash_output"), /sh .*restore-a.sh \/mnt/)
+        expect(Yast::SCR).to receive(:Execute)
+          .with(Yast::Path.new(".target.bash_output"), /sh .*restore-b.sh \/mnt/)
+
+        Yast::Update.restore_backup
+      end
+    end
+
+    context "when the release info does not match" do
+      it "logs an error" do
+        expect(Yast::Update.log).to receive(:error).with(/not restored/)
+
+        Yast::Update.restore_backup
+      end
+
+      it "does not continue" do
+        expect(Yast::SCR).to_not receive(:Execute)
+          .with(Yast::Path.new(".target.bash_output"), /sh .*restore-a.sh \/mnt/)
+        expect(Yast::SCR).to_not receive(:Execute)
+          .with(Yast::Path.new(".target.bash_output"), /sh .*restore-b.sh \/mnt/)
+
+        Yast::Update.restore_backup
+      end
+    end
+  end
 
   describe "#SetDesktopPattern" do
     context "if there is no definition of window manager upgrade path in control file" do

--- a/test/update_test.rb
+++ b/test/update_test.rb
@@ -62,12 +62,26 @@ describe Yast::Update do
 
   describe "#create_backup" do
     before(:each) do
+      allow(::FileUtils).to receive(:cp)
       allow(::FileUtils).to receive(:mkdir_p)
       allow(::File).to receive(:write)
       allow(::FileUtils).to receive(:chmod)
       allow(::File).to receive(:exist?).and_return(true)
+      allow(Pathname).to receive(:new)
       allow(Yast::SCR).to receive(:Execute).with(Yast::Path.new(".target.bash_output"), /^tar /).
         and_return({"exit" => 0})
+    end
+
+    let(:os_release_pathname) { double }
+
+    it "copies the release info file" do
+      allow(Pathname).to receive(:new)
+        .with("#{Yast::Installation.destdir}/etc/os-release")
+        .and_return(os_release_pathname)
+
+      expect(::FileUtils).to receive(:cp).with(os_release_pathname, anything)
+
+      Yast::Update.create_backup('testing', [])
     end
 
     it "create tarball including given name with all paths added" do


### PR DESCRIPTION
> The backup only will be restored when the VERSION_ID matches in both,
the current and backed os-release file.