### PR TITLE
Remove obsolete code

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr  5 14:43:25 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Remove obsolete code.
+- 4.2.1
+
+-------------------------------------------------------------------
 Tue Mar 26 16:29:07 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Remove code related to device name translations.

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -47,10 +47,6 @@ module Yast
       Yast.import "Report"
       Yast.import "Update"
       Yast.import "Installation"
-# storage-ng
-=begin
-      Yast.import "FileSystems"
-=end
       Yast.import "Mode"
       Yast.import "Product"
     end
@@ -180,7 +176,7 @@ module Yast
 
       # exact match
       if arch_1 == arch_2
-        return true 
+        return true
         # ppc exception
       elsif Builtins.contains(ppc_archs, arch_1) &&
           Builtins.contains(ppc_archs, arch_2)


### PR DESCRIPTION
## Problem

After migrating to storage-ng, some code in this module is not used anymore. All leftover code should be removed/adapted for both: to simplify base code and to avoid possible bugs.

PBI: https://trello.com/c/Ct6MP1Xz/824-2-clean-up-storage-ng-notes-fixmes-in-yast-update

## Solution

Leftover code has been removed.

## Testing

Manually tested