### PR TITLE
Uninstall the "SUSE-Manager-Proxy" product (bsc#1133215)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 26 11:03:27 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Uninstall the "SUSE-Manager-Proxy" product when upgrading from
+  SLES12 + SUMA Proxy + SUMA Branch Server (bsc#1133215)
+- 4.1.9
+
+-------------------------------------------------------------------
 Thu Jan 24 18:49:24 UTC 2019 - lslezak@suse.cz
 
 - Added URL tag to the spec file (bsc#1097957)

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -29,7 +29,7 @@ Url:            http://github.com/yast/yast-update
 BuildRequires:	update-desktop-files
 BuildRequires:  yast2-devtools >= 3.1.15
 BuildRequires:  yast2-ruby-bindings >= 1.0.0
-# Y2Packager::obsolete_upgrades
+# Y2Packager::ProductUpgrade.remove_obsolete_upgrades
 BuildRequires:  yast2 >= 4.1.69
 # Packages#proposal_for_update
 BuildRequires:  yast2-packager >= 3.2.13

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.1.8
+Version:        4.1.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -29,7 +29,8 @@ Url:            http://github.com/yast/yast-update
 BuildRequires:	update-desktop-files
 BuildRequires:  yast2-devtools >= 3.1.15
 BuildRequires:  yast2-ruby-bindings >= 1.0.0
-BuildRequires:  yast2 >= 3.1.126
+# Y2Packager::obsolete_upgrades
+BuildRequires:  yast2 >= 4.1.69
 # Packages#proposal_for_update
 BuildRequires:  yast2-packager >= 3.2.13
 
@@ -46,8 +47,8 @@ BuildRequires:  rubygem(rspec)
 BuildRequires:	yast2-storage-ng >= 4.1.31
 # Encryption.save_crypttab_names
 Requires:	yast2-storage-ng >= 4.1.31
-# FSSnapshotStore
-Requires:	yast2 >= 3.1.126
+# Y2Packager::ProductUpgrade.remove_obsolete_upgrades
+Requires:	yast2 >= 4.1.69
 Requires:	yast2-installation
 
 # handle bind mount at /mnt/dev

--- a/src/clients/update_proposal.rb
+++ b/src/clients/update_proposal.rb
@@ -27,6 +27,7 @@
 #
 
 require "cgi/util"
+require "y2packager/product_upgrade"
 
 module Yast
   class UpdateProposalClient < Client
@@ -450,6 +451,10 @@ module Yast
         # Control the upgrade process better
         update_sum = Pkg.PkgUpdateAll(GetUpdateConf())
         Builtins.y2milestone("Update summary: %1", update_sum)
+
+        # deselect the upgraded obsolete products (bsc#1133215)
+        Y2Packager::ProductUpgrade.remove_obsolete_upgrades
+
         Update.unknown_packages = Ops.get(update_sum, :ProblemListSze, 0)
       end
 


### PR DESCRIPTION
when upgrading from SLES12 + SUMA Proxy + SUMA Branch Server

- 4.1.9