### PR TITLE
Select the needed packages bsc#1136012

### DIFF
--- a/src/clients/update_proposal.rb
+++ b/src/clients/update_proposal.rb
@@ -441,11 +441,11 @@ module Yast
 
         Builtins.foreach(restore) { |res| Pkg.ResolvableInstall(res, :product) }
 
-        # make sure the packages needed for accessing the installation repository
-        # are installed, e.g. "cifs-mount" for SMB or "nfs-client" for NFS repositories
-        Packages.sourceAccessPackages.each do |package|
-          Pkg::ResolvableInstall(package, :package)
-        end
+        # install the needed package (e.g. "cifs-mount" for SMB or "nfs-client"
+        # for NFS repositories or "grub2" for the bootloader)
+        # false = allow installing new packages, otherwise it would only upgrade
+        # the already installed packages
+        Packages.SelectSystemPackages(false)
 
         # FATE #301990, Bugzilla #238488
         # Control the upgrade process better


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1136012
- The `Pkg.PkgApplReset` resets the selected packages by YaST
- The code only restores the selected products, not packages
- The `Packages.sourceAccessPackages` call has been replaced by `Packages.SelectSystemPackages`, it internally selectes the source access packages and also the packages needed by YaST modules (e.g. `grub2` needed by the bootloader module)
- **NOT tested!**

### TODO

- [ ] Test that it actually fixes the problem