### PR TITLE
Adapt to new Crypttab API

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 30 15:09:44 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Use new API to save encryption names from crypttab file (part of
+  jsc#SLE-7376).
+- 4.2.6
+
+-------------------------------------------------------------------
 Thu Aug 22 16:03:51 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -39,11 +39,11 @@ BuildRequires:  libxml2-tools
 BuildRequires:  yast2-installation-control
 # Needed for tests
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
-# Encryption.save_crypttab_names
-BuildRequires:  yast2-storage-ng >= 4.1.31
+# Y2Storage::Crypttab.save_encryption_names
+BuildRequires:  yast2-storage-ng >= 4.2.42
 
-# Encryption.save_crypttab_names
-Requires:       yast2-storage-ng >= 4.1.31
+# Y2Storage::Crypttab.save_encryption_names
+Requires:       yast2-storage-ng >= 4.2.42
 # Y2Packager::ProductUpgrade.remove_obsolete_upgrades
 Requires:       yast2 >= 4.2.1
 Requires:       yast2-installation

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1264,7 +1264,8 @@ module Yast
         #
         #   encryption.crypttab_name  #=> "cr_home"
         crypttab_path = File.join(Installation.destdir, "/etc/crypttab")
-        Y2Storage::Encryption.save_crypttab_names(probed, crypttab_path)
+        crypttab = Y2Storage::Crypttab.new(crypttab_path)
+        crypttab.save_encryption_names(probed)
 
         Update.GetProductName
 


### PR DESCRIPTION
### Problem

The method `Y2Storage::Encryption#save_crypttab_names` was replaced by `Y2Storage::Crypttab#save_encryption_names`.

* Requires https://github.com/yast/yast-storage-ng/pull/969

### Solution

Code was adapted to use the new API. 