### PR TITLE
Mount /run as /mnt/run to fix LVM (bsc#1152530)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct  9 08:57:14 UTC 2019 - Martin Vidner <mvidner@suse.com>
+
+- At upgrade time, mount also /run and efivars in the target,
+  to fix hanging LVM tools (bsc#1148500)
+- 3.3.1
+
+-------------------------------------------------------------------
 Thu Jun 20 14:18:15 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Backport: Fixed unmounting /mnt/dev when going back to the

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        3.3.0
+Version:        3.3.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1201,25 +1201,9 @@ module Yast
       end
     end
 
-    #
-    def MountFSTab(fstab, message)
-      fstab = deep_copy(fstab)
-      allowed_fs = [
-        "ext",
-        "ext2",
-        "ext3",
-        "ext4",
-        "btrfs",
-        "minix",
-        "reiserfs",
-        "jfs",
-        "xfs",
-        "xiafs",
-        "hpfs",
-        "vfat",
-        "auto",
-      ]
-
+    # Mount /sys /proc and the like inside Installation.destdir
+    # @return [void]
+    def mount_specials_in_destdir
       # mount sysfs first
       if MountPartition("/sys", "sysfs", "sysfs") == nil
         AddMountedPartition(
@@ -1239,6 +1223,29 @@ module Yast
           { :type => "mount", :device => "devtmpfs", :mntpt => "/dev" }
         )
       end
+    end
+
+    #
+    def MountFSTab(fstab, message)
+      fstab = deep_copy(fstab)
+
+      mount_specials_in_destdir
+
+      allowed_fs = [
+        "ext",
+        "ext2",
+        "ext3",
+        "ext4",
+        "btrfs",
+        "minix",
+        "reiserfs",
+        "jfs",
+        "xfs",
+        "xiafs",
+        "hpfs",
+        "vfat",
+        "auto",
+      ]
 
       success = true
 

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1224,6 +1224,15 @@ module Yast
         )
       end
 
+      efivars_path = "/sys/firmware/efi/efivars"
+      if ::File.exist?(efivars_path)
+        if MountPartition(efivars_path, "efivarfs", "efivarfs") == nil
+          AddMountedPartition(
+            { :type => "mount", :device => "efivarfs", :mntpt => efivars_path }
+          )
+        end
+      end
+
       if SCR.Execute(
           path(".target.mount"),
           ["/run", ::File.join(Installation.destdir, "run"), Installation.mountlog],

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1223,6 +1223,16 @@ module Yast
           { :type => "mount", :device => "devtmpfs", :mntpt => "/dev" }
         )
       end
+
+      if SCR.Execute(
+          path(".target.mount"),
+          ["/run", ::File.join(Installation.destdir, "run"), Installation.mountlog],
+          "--bind"
+         )
+        AddMountedPartition(
+          { :type => "mount", :device => "none", :mntpt => "/run" }
+        )
+      end
     end
 
     #

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1233,6 +1233,8 @@ module Yast
         end
       end
 
+      # MountPartition does not work here
+      # because it turns --bind into -o --bind
       if SCR.Execute(
           path(".target.mount"),
           ["/run", ::File.join(Installation.destdir, "run"), Installation.mountlog],

--- a/test/root_part_test.rb
+++ b/test/root_part_test.rb
@@ -5,4 +5,16 @@ require_relative "test_helper"
 Yast.import "RootPart"
 
 describe Yast::RootPart do
+  describe "#mount_specials_in_destdir" do
+    before do
+      allow(subject).to receive(:MountPartition).and_return(nil)
+      allow(subject).to receive(:AddMountedPartition)
+      expect(File).to receive(:exist?).and_return(true)
+      allow(Yast::SCR).to receive(:Execute).with(Yast::Path, Array, String)
+    end
+
+    it "does not crash" do
+      expect { subject.mount_specials_in_destdir }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
- [bsc#1152530](https://bugzilla.suse.com/show_bug.cgi?id=1152530)
- https://trello.com/c/PN5yWLqx

### Testing

I've installed SLES12-SP4 and upgraded to SP5 (both unregistered, via DVD).
- used a machine with EFI firmware to test the efivars part of the fix (`qemu-kvm -bios /usr/share/qemu/ovmf-x86_64-ms-code.bin ...` from qemu-ovmf-x86_64.rpm)
- changed the partitioning proposal to propose with LVM, to reproduce the bug and test the fix
