### PR TITLE
Pkg.ResolvableProperties removed

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Nov 19 10:59:04 CET 2019 - schubi@suse.de
+
+- Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find
+  in order to decrease the required memory (bsc#1132650,
+  bsc#1140037).
+- 4.2.11
+
+-------------------------------------------------------------------
 Thu Nov  7 14:13:39 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed too eager Rubocop cleanup resulting in "No fstab found"

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -31,8 +31,7 @@ BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-ruby-bindings >= 1.0.0
 # Y2Packager::ProductUpgrade.remove_obsolete_upgrades
 BuildRequires:  yast2 >= 4.2.1
-# product_update_summary, product_update_warning
-BuildRequires:  yast2-packager >= 3.2.33
+BuildRequires:  yast2-packager
 # xmllint
 BuildRequires:  libxml2-tools
 # control.rng

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -31,7 +31,8 @@ BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-ruby-bindings >= 1.0.0
 # Y2Packager::ProductUpgrade.remove_obsolete_upgrades
 BuildRequires:  yast2 >= 4.2.1
-BuildRequires:  yast2-packager
+# Packages#proposal_for_update
+BuildRequires:  yast2-packager >= 3.2.13
 # xmllint
 BuildRequires:  libxml2-tools
 # control.rng

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.2.10
+Version:        4.2.11
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -31,8 +31,8 @@ BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-ruby-bindings >= 1.0.0
 # Y2Packager::ProductUpgrade.remove_obsolete_upgrades
 BuildRequires:  yast2 >= 4.2.1
-# Packages#proposal_for_update
-BuildRequires:  yast2-packager >= 3.2.13
+# product_update_summary, product_update_warning
+BuildRequires:  yast2-packager >= 3.2.33
 # xmllint
 BuildRequires:  libxml2-tools
 # control.rng
@@ -47,8 +47,8 @@ Requires:       yast2-storage-ng >= 4.2.42
 # Y2Packager::ProductUpgrade.remove_obsolete_upgrades
 Requires:       yast2 >= 4.2.1
 Requires:       yast2-installation
-# handle bind mount at /mnt/dev
-Requires:       yast2-packager >= 4.0.61
+# product_update_summary, product_update_warning
+Requires:       yast2-packager >= 4.2.33
 # Pkg.TargetInitializeOptions()
 Requires:       yast2-pkg-bindings >= 3.1.14
 Requires:       yast2-ruby-bindings >= 1.0.0

--- a/src/clients/packages_proposal.rb
+++ b/src/clients/packages_proposal.rb
@@ -24,6 +24,9 @@
 # Purpose:  Let user choose packages during update.
 #
 # $Id$
+
+require "y2packager/resolvable"
+
 module Yast
   unless defined?(PackagesProposalClient)
     class PackagesProposalClient < Client
@@ -177,7 +180,7 @@ module Yast
 
           Builtins.y2milestone(
             "Products: %1",
-            Pkg.ResolvableProperties("", :product, "")
+            Y2Packager::Resolvable.find(kind: :product)
           )
           ret_ref = arg_ref(@ret)
           Packages.CheckOldAddOns(ret_ref)

--- a/src/clients/update_proposal.rb
+++ b/src/clients/update_proposal.rb
@@ -26,6 +26,7 @@
 
 require "cgi/util"
 require "y2packager/product_upgrade"
+require "y2packager/resolvable"
 
 module Yast
   class UpdateProposalClient < Client
@@ -184,7 +185,7 @@ module Yast
           )
         end
 
-        products = Pkg.ResolvableProperties("", :product, "")
+        products = Y2Packager::Resolvable.find(kind: :product)
         # stores the proposal text output
         @summary_text = Packages.product_update_summary(products)
           .map { |item| "<li>#{item}</li>" }.join
@@ -423,13 +424,11 @@ module Yast
         # products to reselect after reset
         restore = []
 
-        Pkg.ResolvableProperties("", :product, "").each do |product|
+        Y2Packager::Resolvable.find(kind: :product).each do |product|
           # only selected items but ignore the selections done by solver,
           # during restoration they would be changed to be selected by YaST and they
           # will be selected by solver again anyway
-          if product["status"] == :selected && product["transact_by"] != :solver
-            restore << product["name"]
-          end
+          restore << product.name if product.status == :selected && product.transact_by != :solver
         end
 
         Pkg.PkgApplReset

--- a/src/clients/update_proposal.rb
+++ b/src/clients/update_proposal.rb
@@ -424,11 +424,11 @@ module Yast
         # products to reselect after reset
         restore = []
 
-        Y2Packager::Resolvable.find(kind: :product).each do |product|
+        Y2Packager::Resolvable.find(kind: :product, status: :selected).each do |product|
           # only selected items but ignore the selections done by solver,
           # during restoration they would be changed to be selected by YaST and they
           # will be selected by solver again anyway
-          restore << product.name if product.status == :selected && product.transact_by != :solver
+          restore << product.name if product.transact_by != :solver
         end
 
         Pkg.PkgApplReset

--- a/src/modules/Update.rb
+++ b/src/modules/Update.rb
@@ -225,10 +225,10 @@ module Yast
     def SelectedProducts
       selected = Y2Packager::Resolvable.find(kind: :product, status: :selected)
 
-      selected.map do |p|
-        next p.display_name unless p.display_name.empty?
-        next p.summary unless p.summary.empty?
-        next p.name unless p.name.empty?
+      selected.map do |product|
+        next product.display_name unless product.display_name.empty?
+        next product.summary unless product.summary.empty?
+        next product.name unless product.name.empty?
 
         _("Unknown Product")
       end

--- a/src/modules/Update.rb
+++ b/src/modules/Update.rb
@@ -229,7 +229,6 @@ module Yast
         next p.display_name unless p.display_name.empty?
         next p.summary unless p.summary.empty?
         next p.name unless p.name.empty?
-        next p.version unless p.version.empty?
 
         _("Unknown Product")
       end


### PR DESCRIPTION
Replacing old Pkg.ResolvableProperties()and Pkg.ResolvabeDependencies() calls by Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find in order to save memory.