### PR TITLE
use control register target also for online update

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec  4 14:29:12 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- fix upgrade for online medium (bsc#1158056 and bsc#1157636)
+- 4.2.12
+
+-------------------------------------------------------------------
 Tue Nov 19 10:59:04 CET 2019 - schubi@suse.de
 
 - Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.2.11
+Version:        4.2.12
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -512,7 +512,7 @@ module Yast
 
     def target_distribution
       # FIXME: this is the same as in src/lib/update/clients/inst_update_partition_auto.rb:113
-      if Y2Packager::MediumType.offline?
+      if Y2Packager::MediumType.offline? || Y2Packager::MediumType.online?
         control_products = Y2Packager::ProductControlProduct.products
         # currently all products have the same "register_target" value
         return control_products.first&.register_target || ""


### PR DESCRIPTION
## Problem

The upgrade process crash when using the online media because `No base product found`

<details>
<summary>Click to show/hide screenshot</summary>

---

![canvas](https://user-images.githubusercontent.com/1691872/70154625-baa65080-16a8-11ea-872d-16743bd04b05.png)


</details>

Bugzilla:

* [#1157636](https://bugzilla.suse.com/show_bug.cgi?id=1157636)
* [#1158056](https://bugzilla.suse.com/show_bug.cgi?id=1158056)

Trello:

* https://trello.com/c/pyqFurT6
* https://trello.com/c/Rhvu29XB

## Solution

Use registration target defined in control.xml also for Online medium like we do for Full medium.

## Tests

* Tested manually (currently in progress)