### PR TITLE
Save the original repository setup (bsc#1159433)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jan 28 10:23:51 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Store the original repository setup early in the upgrade workflow
+  so YaST can easily differ between the old and new repositories
+  (bsc#1159433)
+- 4.2.14
+
+-------------------------------------------------------------------
 Fri Jan  3 14:51:57 CET 2020 - schubi@suse.de
 
 - Aborting upgrade: Restoring old settings e.g. RPM database

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.2.13
+Version:        4.2.14
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST
@@ -29,8 +29,8 @@ Source0:        %{name}-%{version}.tar.bz2
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-ruby-bindings >= 1.0.0
-# Y2Packager::ProductUpgrade.remove_obsolete_upgrades
-BuildRequires:  yast2 >= 4.2.1
+# Y2Packager::OriginalRepositorySetup
+BuildRequires:  yast2 >= 4.2.60
 # Packages#proposal_for_update
 BuildRequires:  yast2-packager >= 3.2.13
 # xmllint
@@ -44,8 +44,8 @@ BuildRequires:  yast2-storage-ng >= 4.2.42
 
 # Y2Storage::Crypttab.save_encryption_names
 Requires:       yast2-storage-ng >= 4.2.42
-# Y2Packager::ProductUpgrade.remove_obsolete_upgrades
-Requires:       yast2 >= 4.2.1
+# Y2Packager::OriginalRepositorySetup
+Requires:       yast2 >= 4.2.60
 Requires:       yast2-installation
 # product_update_summary, product_update_warning
 Requires:       yast2-packager >= 4.2.33

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -30,6 +30,7 @@ require "yast"
 
 require "y2packager/medium_type"
 require "y2packager/product_control_product"
+require "y2packager/original_repository_setup"
 
 module Yast
   module UpdateRootpartInclude
@@ -504,6 +505,15 @@ module Yast
               )
             end
           end
+        end
+
+        if ret != :back
+          # force reloading the repositories
+          Yast::Pkg.SourceFinishAll
+          Yast::Pkg.SourceRestore
+
+          # remember the original repositories
+          Y2Packager::OriginalRepositorySetup.instance.read
         end
       end
 


### PR DESCRIPTION
## Details

- Related to https://bugzilla.suse.com/show_bug.cgi?id=1159433
- We need to remember the original repositories just after mounting the partition selected to upgrade.
- See also https://github.com/yast/yast-yast2/pull/1010

## Tests

- Tested manually together with the other changes.

## Notes

- Fails in Travis because of the new dependency, see https://github.com/yast/yast-yast2/pull/1010