### PR TITLE
Also accept Packages.db as valid rpm database (bsc#1162485)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 17 15:43:57 CET 2020 - mls@suse.de
+
+- Also accept Packages.db as valid rpm database (bsc#1162485)
+- 4.2.15
+
+-------------------------------------------------------------------
 Tue Jan 28 10:23:51 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Store the original repository setup early in the upgrade workflow

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.2.14
+Version:        4.2.15
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST

--- a/src/clients/update_proposal.rb
+++ b/src/clients/update_proposal.rb
@@ -286,7 +286,11 @@ module Yast
       )
 
       # at least one must be there, the second one is for RPM v3
-      rpm_db_files = ["/var/lib/rpm/Packages", "/var/lib/rpm/packages.rpm"]
+      rpm_db_files = [
+        "/var/lib/rpm/Packages",
+        "/var/lib/rpm/packages.rpm",
+        "/var/lib/rpm/Packages.db"
+      ]
       ret = false
       file_found_or_error_skipped = false
 


### PR DESCRIPTION
This is the fast and easy way to get this into Factory, where is is needed ASAP. Feel free to implement one of the other choices mentioned in bugzilla later on.