### PR TITLE
Fixed user-visible messages (bsc#1084015)

### DIFF
--- a/control/update.xml
+++ b/control/update.xml
@@ -68,7 +68,7 @@ textdomain="update"
     </workflows>
     <inst_finish_stages config:type="list">
 	<inst_finish_stage>
-	    <label>Update Configuration</label>
+	    <label>Configure Online Update</label>
 	    <steps config:type="list">
 		<step>pkg</step>
 	    </steps>

--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 19 09:57:26 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed user-visible messages (bsc#1084015)
+- 4.2.16
+
+-------------------------------------------------------------------
 Mon Feb 17 15:43:57 CET 2020 - mls@suse.de
 
 - Also accept Packages.db as valid rpm database (bsc#1162485)

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.2.15
+Version:        4.2.16
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST


### PR DESCRIPTION
## Bugzilla 

https://bugzilla.suse.com/show_bug.cgi?id=1084015


## Description

This puts en_US "translations" which are really fixes for broken English or broken translations back into the sources.


#### en_US.po File

```po
# English message file for YaST2 (@memory@).
# Copyright (C) 2005 SUSE Linux Products GmbH.
# Copyright (C) 2002 SuSE Linux AG.
#
msgid ""
msgstr ""
"Project-Id-Version: YaST (@memory@)\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2020-01-08 02:29+0000\n"
"PO-Revision-Date: 2002-07-18 14:04+0200\n"
"Last-Translator: proofreader <i18n@suse.de>\n"
"Language-Team: English <i18n@suse.de>\n"
"Language: en_US\n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Plural-Forms: nplurals=2; plural=n != 1;"

#: control/update.glade.translations.glade:9
msgid "Update Configuration"
msgstr "Configure Online Update"
```

## Where does this Message Come From?

I had to reverse-engineer where that message comes from. It turns out that our `rake pot` magic preprocesses `control.xml` file snippets, and that process creates this temporary file  `control/update.glade.translations.glade`. Of course, the GNU gettext tools write the name of the file that they process into the resulting `.pot` file with no hint about where the message originally comes from.

_Another case of our daily YaST software archaeology._
