### PR TITLE
Fixed repository loading (bsc#1163081)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 21 09:06:01 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed repository loading to not remove the initial installation
+  repository (bsc#1163081)
+- 4.2.17
+
+-------------------------------------------------------------------
 Wed Feb 19 14:43:22 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Switch from Autotools based build to Rake

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.2.16
+Version:        4.2.17
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST
@@ -50,8 +50,8 @@ Requires:       yast2 >= 4.2.60
 Requires:       yast2-installation
 # product_update_summary, product_update_warning
 Requires:       yast2-packager >= 4.2.33
-# Pkg.TargetInitializeOptions()
-Requires:       yast2-pkg-bindings >= 3.1.14
+# Improved Pkg.SourceRestore()
+Requires:       yast2-pkg-bindings >= 4.2.6
 Requires:       yast2-ruby-bindings >= 1.0.0
 # use parallel gzip when crating backup (much faster)
 Requires:       pigz
@@ -118,7 +118,5 @@ Use this component if you wish to update your system.
 %{yast_clientdir}/update.rb
 %{yast_clientdir}/run_update.rb
 %license COPYING
-%doc %{yast_docdir}/README.md
-%doc %{yast_docdir}/CONTRIBUTING.md
 
 %changelog

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -508,11 +508,9 @@ module Yast
         end
 
         if ret != :back
-          # force reloading the repositories
-          Yast::Pkg.SourceFinishAll
+          # load the repositories from the system
           Yast::Pkg.SourceRestore
-
-          # remember the original repositories
+          # remember the original setup
           Y2Packager::OriginalRepositorySetup.instance.read
         end
       end


### PR DESCRIPTION
- Do not remove the initial installation repository
- The `Pkg.SourceRestore` was no operation when a repository was present, to force it to work the workaround was to call `Pkg.SourceFinishAll` to forget all repositories. Unfortunately this caused removing the initial installation repository in openSUSE.
- See related https://github.com/yast/yast-pkg-bindings/pull/125

Note: the spec file change was introduced in the previous PR #150. I wrongly checked in which packages it was, that caused file conflict (https://ci.suse.de/job/yast-yast-update-master/25/console).