### PR TITLE
Do not remove the installation repositories (bsc#1163081)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 12 08:52:36 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not remove the installation repositories in the "Previously
+  Used Repositories" step (bsc#1163081)
+- 4.2.18
+
+-------------------------------------------------------------------
 Fri Feb 21 09:06:01 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed repository loading to not remove the initial installation

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.2.17
+Version:        4.2.18
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST
@@ -30,7 +30,7 @@ BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-ruby-bindings >= 1.0.0
 # Y2Packager::OriginalRepositorySetup
-BuildRequires:  yast2 >= 4.2.60
+BuildRequires:  yast2 >= 4.2.71
 # Packages#proposal_for_update
 BuildRequires:  yast2-packager >= 3.2.13
 # xmllint
@@ -46,7 +46,7 @@ BuildRequires:  yast2-storage-ng >= 4.2.42
 # Y2Storage::Crypttab.save_encryption_names
 Requires:       yast2-storage-ng >= 4.2.42
 # Y2Packager::OriginalRepositorySetup
-Requires:       yast2 >= 4.2.60
+Requires:       yast2 >= 4.2.71
 Requires:       yast2-installation
 # product_update_summary, product_update_warning
 Requires:       yast2-packager >= 4.2.33

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -29,8 +29,9 @@
 require "yast"
 
 require "y2packager/medium_type"
-require "y2packager/product_control_product"
 require "y2packager/original_repository_setup"
+require "y2packager/product_control_product"
+require "y2packager/repository"
 
 module Yast
   module UpdateRootpartInclude
@@ -508,10 +509,12 @@ module Yast
         end
 
         if ret != :back
+          install_repos = Y2Packager::Repository.all
+          log.info "Installation repositories (#{install_repos.size}): #{install_repos.map(&:url)}"
           # load the repositories from the system
           Yast::Pkg.SourceRestore
-          # remember the original setup
-          Y2Packager::OriginalRepositorySetup.instance.read
+          # remember the original setup, ignore the installation repositories
+          Y2Packager::OriginalRepositorySetup.instance.read(install_repos)
         end
       end
 


### PR DESCRIPTION
- Do not remove the installation repositories in the "Previously Used Repositories" step
- https://bugzilla.suse.com/show_bug.cgi?id=1163081
- https://openqa.opensuse.org/tests/1194286#step/upgrade_select/3
- Related to https://github.com/yast/yast-yast2/pull/1030
- Tested manually
- 4.2.18