### PR TITLE
Fixed selecting the base product (bsc#1176276)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 14 09:01:10 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed selecting the base product (e.g. SLES) during upgrade
+  (bsc#1176276)
+- 4.2.20
+
+-------------------------------------------------------------------
 Thu Sep 17 16:49:12 CEST 2020 - schubi@suse.de
 
 - Adding additional compatible vendors which are defined in the

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.2.19
+Version:        4.2.20
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST

--- a/src/clients/update_proposal.rb
+++ b/src/clients/update_proposal.rb
@@ -428,7 +428,9 @@ module Yast
         # products to reselect after reset
         restore = []
 
-        Y2Packager::Resolvable.find(kind: :product, status: :selected).each do |product|
+        # preload the "transact_by" attribute to avoid querying libzypp again (see bsc#1176276)
+        Y2Packager::Resolvable.find({ kind: :product, status: :selected }, [:transact_by])
+          .each do |product|
           # only selected items but ignore the selections done by solver,
           # during restoration they would be changed to be selected by YaST and they
           # will be selected by solver again anyway


### PR DESCRIPTION
- Fix (or rather a workaround) for bug https://bugzilla.suse.com/show_bug.cgi?id=1176276
- It is an migration from SLE15-SP1 to SLE15-SP2 via an SMT server

## Details

- I found this message in the y2log:
  `y2packager/resolvable.rb:152 Found several resolvables: [{"transact_by"=>:solver}, {"transact_by"=>:app_high}]`
- That means the [`Resolvable`](https://github.com/yast/yast-yast2/blob/ab3fee8654cb2b7cca315f9d56b260034fa775dd/library/packages/src/lib/y2packager/resolvable.rb#L45) class found two resolvables when lazy loading the requested `transact_by` attribute (the [code](https://github.com/yast/yast-yast2/blob/ab3fee8654cb2b7cca315f9d56b260034fa775dd/library/packages/src/lib/y2packager/resolvable.rb#L161))
- But that's very strange, to later find the original resolvable in libzypp again we compare the name, version, architecture, repository and type of the resolvable ([link](https://github.com/yast/yast-yast2/blob/ab3fee8654cb2b7cca315f9d56b260034fa775dd/library/packages/src/lib/y2packager/resolvable.rb#L139-L140)). There should be no duplicates, the same repository should never contain the very same package (in the same version!) multiple times...

## Solution

- Fortunately the `Resovable` class allows preloading the requested attributes in the initial search, that means it's possible to avoid the ambiguity in the lazy loading.
- Additionally it should be a bit faster (avoid querying libzypp again for each product)
- But as this is hard to reproduce (I used the same SMT server and it was fine for me) let's use this workaround here for now, if we get more details (or be able to reproduce the problem) we can fix the root issue later..
