### PR TITLE
Fixed unit test

### DIFF
--- a/test/root_part_test.rb
+++ b/test/root_part_test.rb
@@ -236,6 +236,7 @@ describe Yast::RootPart do
     let(:device_spec) { nil }
 
     it "mounts /dev, /proc, /run, and /sys" do
+      allow(File).to receive(:exist?).with("/sys/firmware/efi/efivars").and_return(false)
       allow(subject).to receive(:AddMountedPartition)
 
       ["/dev", "/proc", "/run", "/sys"].each do |d|


### PR DESCRIPTION
- Do not read the real `/sys/firmware/efi/efivars` directory from the testing system.
- Related to the previous PR #160, when running `rake osc:sr` on my machine I got this error:
```
received :MountPartition with unexpected arguments
         expected: ("/dev", anything, anything, *(any args))
              got: ("/sys/firmware/efi/efivars", "efivarfs", "efivarfs")
```

My machine uses EFI so that directory exists and YaST wants to do an extra mount not mocked in the tests.