### PR TITLE
bsc#1180142: do not use 'installation-helper' to create snapshots

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon Dec 21 10:57:20 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not rely on the 'installation-helper' binary to create
+  snapshots after installation or offline upgrade (bsc#1180142).
+- Do not crash when it is not possible to create a snapshot before
+  upgrading the system (related to bsc#1180142).
+- 4.1.13
+
+-------------------------------------------------------------------
 Fri Jan  3 14:51:57 CET 2020 - schubi@suse.de
 
 - Aborting upgrade: Restoring old settings e.g. RPM database

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.1.12
+Version:        4.1.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -2447,8 +2447,8 @@ module Yast
     rescue Yast2::SnapshotCreationFailed => error
       log.error("Error creating a pre-update snapshot: #{error}")
       Yast::Report.Error(
-        _("A pre-update snapshot could not be created. You can continue with the " \
-          "installation, but beware that you cannot roll back to a pre-update state " \
+        _("A pre-update snapshot could not be created. You can continue with the \n" \
+          "installation, but beware that you cannot roll back to a pre-update state \n" \
           "unless you have created a snapshot manually.")
       )
     ensure

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1724,11 +1724,7 @@ module Yast
       else
         # enter the mount points of the newly mounted partitions
         update_staging!
-        if Yast2::FsSnapshot.configured?
-          # as of bsc #1092757 snapshot descriptions are not translated
-          snapshot = Yast2::FsSnapshot.create_pre("before update", cleanup: :number, important: true)
-          Yast2::FsSnapshotStore.save("update", snapshot.number)
-        end
+        create_pre_snapshot
         Update.clean_backup
         create_backup
         inject_intsys_files
@@ -2434,6 +2430,23 @@ module Yast
       # In the /var case, it should have been already processed by
       # #MountVarIfRequired... except when /var is a subvolume
       path != "/var" || mntops.include?("subvol=")
+    end
+
+    # Creates a pre-update snapshot and stores its number
+    #
+    # If something goes wrong, it reports the problem to the user.
+    def create_pre_snapshot
+      return unless Yast2::FsSnapshot.configured?
+
+      # as of bsc #1092757 snapshot descriptions are not translated
+      snapshot = Yast2::FsSnapshot.create_pre("before update", cleanup: :number, important: true)
+      Yast2::FsSnapshotStore.save("update", snapshot.number)
+    rescue Yast2::SnapshotCreationFailed
+      Yast::Report.Error(
+        _("A pre-update snapshot could not be created. You can continue with the " \
+          "installation, but beware that you cannot roll back to a pre-update state " \
+          "unless you have created a snapshot manually.")
+      )
     end
   end
 

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -2438,6 +2438,9 @@ module Yast
     def create_pre_snapshot
       return unless Yast2::FsSnapshot.configured?
 
+      original_scr = WFM.SCRGetDefault()
+      chroot_scr = WFM.SCROpen("chroot=#{Installation.destdir}:scr", false)
+      WFM.SCRSetDefault(chroot_scr)
       # as of bsc #1092757 snapshot descriptions are not translated
       snapshot = Yast2::FsSnapshot.create_pre("before update", cleanup: :number, important: true)
       Yast2::FsSnapshotStore.save("update", snapshot.number)
@@ -2447,6 +2450,8 @@ module Yast
           "installation, but beware that you cannot roll back to a pre-update state " \
           "unless you have created a snapshot manually.")
       )
+    ensure
+      WFM.SCRSetDefault(original_scr) if original_scr
     end
   end
 

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -2444,7 +2444,8 @@ module Yast
       # as of bsc #1092757 snapshot descriptions are not translated
       snapshot = Yast2::FsSnapshot.create_pre("before update", cleanup: :number, important: true)
       Yast2::FsSnapshotStore.save("update", snapshot.number)
-    rescue Yast2::SnapshotCreationFailed
+    rescue Yast2::SnapshotCreationFailed => error
+      log.error("Error creating a pre-update snapshot: #{error}")
       Yast::Report.Error(
         _("A pre-update snapshot could not be created. You can continue with the " \
           "installation, but beware that you cannot roll back to a pre-update state " \

--- a/test/root_part_test.rb
+++ b/test/root_part_test.rb
@@ -267,6 +267,7 @@ describe Yast::RootPart do
     let(:device_spec) { nil }
 
     it "mounts /dev, /proc, /run, and /sys" do
+      allow(subject).to receive(:MountPartition)
       allow(subject).to receive(:AddMountedPartition)
 
       ["/dev", "/proc", "/run", "/sys"].each do |d|


### PR DESCRIPTION
* If creating the snapshot before updating the system fails, the error is reported and handled properly
* Adapt to `FsSnapshot` API changes introduced in https://github.com/yast/yast-yast2/pull/1125.