### PR TITLE
Do not switch the root when creating the pre-snapshot

### DIFF
--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -2438,9 +2438,6 @@ module Yast
     def create_pre_snapshot
       return unless Yast2::FsSnapshot.configured?
 
-      original_scr = WFM.SCRGetDefault()
-      chroot_scr = WFM.SCROpen("chroot=#{Installation.destdir}:scr", false)
-      WFM.SCRSetDefault(chroot_scr)
       # as of bsc #1092757 snapshot descriptions are not translated
       snapshot = Yast2::FsSnapshot.create_pre("before update", cleanup: :number, important: true)
       Yast2::FsSnapshotStore.save("update", snapshot.number)
@@ -2451,8 +2448,6 @@ module Yast
           "installation, but beware that you cannot roll back to a pre-update state \n" \
           "unless you have created a snapshot manually.")
       )
-    ensure
-      WFM.SCRSetDefault(original_scr) if original_scr
     end
   end
 


### PR DESCRIPTION
Do not switch the root when creating the pre-snapshot during upgrade. It simplifies #162. See https://github.com/yast/yast-yast2/pull/1138 for context.