### PR TITLE
Do not crash when fstab does not contain any entry

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 10 13:32:43 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when an /etc/fstab file does not contain any
+  entry (bsc#1186895).
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0 (bsc#1185510)

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1579,7 +1579,7 @@ module Yast
               Builtins.y2warning("Cannot find / entry in fstab %1", fstab)
             end
 
-            freshman[:valid] = fstab_entry_matches?(fstab[0], filesystem)
+            freshman[:valid] = fstab_entry_matches?(fstab[0], filesystem) if fstab[0]
 
             if Mode.autoinst
               # we dont care about the other checks in autoinstallation


### PR DESCRIPTION
[bsc#1186895](https://bugzilla.suse.com/show_bug.cgi?id=1186895)

During upgrade, when YaST is inspecting the fstab files, it may happen that one of those files does not contain any valid entry (according to our agent). In such a case, YaST will simply crash.

You can reproduce the problem by writing a `/etc/fstab` file with just a comment (so it is not empty but it does not contain any entry).

This PR prevents such a crash, so YaST can continue analyzing the partition.