### PR TITLE
Bind-mount /run once

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 23 08:56:04 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Avoid to bind-mount /run twice (bsc#1181066).
+- 4.2.22
+
+-------------------------------------------------------------------
 Wed Feb 10 09:12:10 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not rely on the 'installation-helper' binary to create

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.2.21
+Version:        4.2.22
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -818,18 +818,6 @@ module Yast
           )
         end
       end
-
-      # MountPartition does not work here
-      # because it turns --bind into -o --bind
-      if SCR.Execute(
-        path(".target.mount"),
-        ["/run", ::File.join(Installation.destdir, "run"), Installation.mountlog],
-        "--bind"
-      )
-        AddMountedPartition(
-          type: "mount", device: "none", mntpt: "/run"
-        )
-      end
     end
 
     def MountFSTab(fstab, _message)


### PR DESCRIPTION
## Problem

The */run* directory is bind-mounted to */mnt/run* twice. This hides submounts from */run*, affecting some upgrade scenarios, specially in an online update.

* https://bugzilla.suse.com/show_bug.cgi?id=1181066

## Solution

Avoid bind-mount */run* twice.

## Testing

Manually tested. Now, */run* is bind-mounted once, and the update works (tested Leap 15.1 to Leap 15.2).