### PR TITLE
Fixed crash during system upgrade (bsc#1189590)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Sep  6 14:08:12 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed crash during system upgrade (synchronize the YaST and
+  libzypp repositories to avoid deleting caches for used
+  repositories) (bsc#1189590)
+- 4.4.3
+
+-------------------------------------------------------------------
 Fri Jul 23 08:56:04 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Avoid to bind-mount /run twice (bsc#1181066).

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST

--- a/src/clients/update_proposal.rb
+++ b/src/clients/update_proposal.rb
@@ -392,6 +392,8 @@ module Yast
       PackageCallbacks.SetConvertDBCallbacks
 
       Pkg.TargetInit(Installation.destdir, false)
+      # sync the YaST and libzypp repositories to avoid possible crashes (bsc#1189590)
+      Pkg.SourceSaveAll
 
       Update.GetProductName
 


### PR DESCRIPTION
## The Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1189590
- Synchronize the YaST repositories to libzypp (save them to the target system)
- This avoids deleting the caches which seems to be unused for libzypp but they are actually still used by YaST

# Testing

- Tested manually, it seems it needs some specific repository setup in the upgraded system, I could not reproduce the problem with my installed TW. I had to download the disk image with the old system from openQA to reproduce it.
- With the patch the upgrade process does not crash anymore