### PR TITLE
Backport fix for bsc#1180142 to SLE 12

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Dec 10 11:51:32 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not rely on the 'installation-helper' binary to create
+  snapshots after installation or offline upgrade (bsc#1180142).
+- Do not crash when it is not possible to create a snapshot before
+  upgrading the system (related to bsc#1180142).
+- 3.2.2.1
+
+-------------------------------------------------------------------
 Wed Apr 19 14:38:34 UTC 2017 - lslezak@suse.cz
 
 - Fixed parsing whitespace lines in the original /etc/fstab

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        3.2.2
+Version:        3.2.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -1808,11 +1808,7 @@ module Yast
         # enter the mount points of the newly mounted partitions
         # in the target map of the storage module
         AddToTargetMap()
-        if Yast2::FsSnapshot.configured?
-          # TRANSLATORS: label for filesystem snapshot taken before system update
-          snapshot = Yast2::FsSnapshot.create_pre(_("before update"), cleanup: :number, important: true)
-          Yast2::FsSnapshotStore.save("update", snapshot.number)
-        end
+        create_pre_snapshot
         Update.clean_backup
         create_backup
       end
@@ -2287,6 +2283,25 @@ module Yast
     publish :function => :GetDistroArch, :type => "string ()"
     publish :function => :mount_target, :type => "boolean ()"
     publish :function => :Detect, :type => "void ()"
+
+  private
+
+    # Creates a pre-update snapshot and stores its number
+    #
+    # If something goes wrong, it reports the problem to the user.
+    def create_pre_snapshot
+      return unless Yast2::FsSnapshot.configured?
+
+      # as of bsc #1092757 snapshot descriptions are not translated
+      snapshot = Yast2::FsSnapshot.create_pre("before update", cleanup: :number, important: true)
+      Yast2::FsSnapshotStore.save("update", snapshot.number)
+    rescue Yast2::SnapshotCreationFailed
+      Yast::Report.Error(
+        _("A pre-update snapshot could not be created. You can continue with the " \
+          "installation, but beware that you cannot roll back to a pre-update state " \
+          "unless you have created a snapshot manually.")
+      )
+    end
   end
 
   RootPart = RootPartClass.new

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -2298,8 +2298,8 @@ module Yast
     rescue Yast2::SnapshotCreationFailed => error
       log.error("Error creating a pre-update snapshot: #{error}")
       Yast::Report.Error(
-        _("A pre-update snapshot could not be created. You can continue with the " \
-          "installation, but beware that you cannot roll back to a pre-update state " \
+        _("A pre-update snapshot could not be created. You can continue with the \n" \
+          "installation, but beware that you cannot roll back to a pre-update state \n" \
           "unless you have created a snapshot manually.")
       )
     end

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -2295,7 +2295,8 @@ module Yast
       # as of bsc #1092757 snapshot descriptions are not translated
       snapshot = Yast2::FsSnapshot.create_pre("before update", cleanup: :number, important: true)
       Yast2::FsSnapshotStore.save("update", snapshot.number)
-    rescue Yast2::SnapshotCreationFailed
+    rescue Yast2::SnapshotCreationFailed => error
+      log.error("Error creating a pre-update snapshot: #{error}")
       Yast::Report.Error(
         _("A pre-update snapshot could not be created. You can continue with the " \
           "installation, but beware that you cannot roll back to a pre-update state " \

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,9 @@
 ENV["Y2DIR"] = File.join(File.expand_path(File.dirname(__FILE__)), "../src/")
 
+# make sure we run the tests in English locale
+# (some tests check the output which is marked for translation)
+ENV["LC_ALL"] = "en_US.UTF-8"
+
 require "yast"
 require "yast/rspec"
 require_relative "helpers"

--- a/test/update_test.rb
+++ b/test/update_test.rb
@@ -107,7 +107,7 @@ describe Yast::Update do
       paths = ["/path_with_slash"]
       expect(Yast::SCR).to receive(:Execute).with(Yast::Path.new(".target.bash_output"), /tar/).
         and_return({"exit" => 1})
-      expect{Yast::Update.create_backup(name, paths)}.to raise_error
+      expect{Yast::Update.create_backup(name, paths)}.to raise_error(RuntimeError)
     end
 
     it "create restore script" do
@@ -156,7 +156,7 @@ describe Yast::Update do
 
         expect(Yast::Y2Logger.instance).to receive(:info) do |msg|
           expect(msg).to match(/upgrade is not handled by this product/i)
-        end.and_call_original
+        end
 
         expect(Yast::Update.SetDesktopPattern).to eq(true)
       end
@@ -169,7 +169,7 @@ describe Yast::Update do
 
         expect(Yast::Y2Logger.instance).to receive(:warn) do |msg|
           expect(msg).to match(/(Sysconfig file .* does not exist|cannot read default window manager)/i)
-        end.twice.and_call_original
+        end.twice
 
         expect(Yast::Update.SetDesktopPattern).to eq(true)
       end
@@ -183,7 +183,7 @@ describe Yast::Update do
 
         expect(Yast::Y2Logger.instance).to receive(:info) do |msg|
           expect(msg).to match(/no matching desktop found .* #{installed_desktop}/i)
-        end.and_call_original
+        end
 
         expect(Yast::Update.SetDesktopPattern).to eq(true)
       end
@@ -198,7 +198,7 @@ describe Yast::Update do
 
         expect(Yast::Y2Logger.instance).to receive(:info) do |msg|
           expect(msg).to match(/(package .* installed: false|not all packages .* are installed)/i)
-        end.twice.and_call_original
+        end.twice
 
         expect(Yast::Update.SetDesktopPattern).to eq(true)
       end


### PR DESCRIPTION
Backport fix for [bsc#1180142](https://bugzilla.suse.com/show_bug.cgi?id=1180142) to SLE 12 SP3. Please, check #166 for details about the original fix.

Related to:

* https://github.com/yast/yast-yast2/pull/1211
* https://github.com/yast/yast-installation/pull/1003

