### PR TITLE
[SP3] Use the "norecovery" mount option (bsc#1195894)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 14 17:20:32 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Use the "norecovery" mount option when searching the root
+  partitions (bsc#1195894)
+- 4.3.4
+
+-------------------------------------------------------------------
 Fri Jul 23 08:56:04 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Avoid to bind-mount /run twice (bsc#1181066).

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST

--- a/test/root_part_test.rb
+++ b/test/root_part_test.rb
@@ -380,4 +380,35 @@ describe Yast::RootPart do
       end
     end
   end
+
+  describe "#CheckPartition" do
+    before do
+      stub_storage(scenario)
+      allow(Yast::SCR).to receive(:Execute)
+    end
+
+    let(:scenario) { "two-disks-two-btrfs.xml" }
+
+    it "uses 'norecovery' mount option for Btrfs" do
+      # return failure to avoid scanning for /etc/fstab
+      expect(Yast::SCR).to receive(:Execute)
+        .with(Yast.path(".target.mount"), Array, "-o ro,norecovery")
+        .and_return(false)
+
+      fs = Y2Storage::StorageManager.instance.probed.blk_filesystems.first
+      subject.CheckPartition(fs)
+    end
+
+    it "does not use 'norecovery` mount option for Ext2" do
+      # return failure to avoid scanning for /etc/fstab
+      expect(Yast::SCR).to receive(:Execute)
+        .with(Yast.path(".target.mount"), Array, "-o ro")
+        .and_return(false)
+
+      fs = Y2Storage::StorageManager.instance.probed.blk_filesystems.first
+      allow(fs).to receive(:type).and_return(Y2Storage::Filesystems::Type::EXT2)
+
+      subject.CheckPartition(fs)
+    end
+  end
 end


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1195894
- Use the `norecovery` mount option when searching the root partitions

## Testing

- Tested manually with Btrfs root partition