### PR TITLE
[SP4] Use the "norecovery" mount option (bsc#1195894)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug  4 15:06:09 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Use the "norecovery" mount option when searching the root
+  partitions (bsc#1195894)
+- 4.4.7
+
+-------------------------------------------------------------------
 Wed Dec  1 07:50:46 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash after selecting the system to upgrade when using

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.4.6
+Version:        4.4.7
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST

--- a/src/modules/RootPart.rb
+++ b/src/modules/RootPart.rb
@@ -37,6 +37,9 @@ module Yast
     include Logger
     NON_MODULAR_FS = ["devtmpfs", "none", "proc", "sysfs"].freeze
 
+    # filesystems which support the "norecovery" mount options
+    NORECOVERY_FS = [:btrfs, :ext3, :ext4, :xfs].freeze
+
     def main
       Yast.import "UI"
 
@@ -1303,13 +1306,16 @@ module Yast
           SCR.Execute(path(".target.modprobe"), mount_type, "")
         end
 
+        mount_options = ["ro"]
+        mount_options << "norecovery" if NORECOVERY_FS.include?(freshman[:fs])
+
         # mount (read-only) partition to Installation::destdir
-        log.debug("Mounting #{[p_dev, Installation.destdir, Installation.mountlog].inspect}")
+        log.info "Mounting #{p_dev} with options #{mount_options}"
         mount =
           SCR.Execute(
             path(".target.mount"),
             [p_dev, Installation.destdir, Installation.mountlog],
-            "-o ro"
+            "-o #{mount_options.join(",")}"
           )
 
         if Convert.to_boolean(mount)

--- a/test/root_part_test.rb
+++ b/test/root_part_test.rb
@@ -400,4 +400,35 @@ describe Yast::RootPart do
       end
     end
   end
+
+  describe "#CheckPartition" do
+    before do
+      stub_storage(scenario)
+      allow(Yast::SCR).to receive(:Execute)
+    end
+
+    let(:scenario) { "two-disks-two-btrfs.xml" }
+
+    it "uses 'norecovery' mount option for Btrfs" do
+      # return failure to avoid scanning for /etc/fstab
+      expect(Yast::SCR).to receive(:Execute)
+        .with(Yast.path(".target.mount"), Array, "-o ro,norecovery")
+        .and_return(false)
+
+      fs = Y2Storage::StorageManager.instance.probed.blk_filesystems.first
+      subject.CheckPartition(fs)
+    end
+
+    it "does not use 'norecovery` mount option for Ext2" do
+      # return failure to avoid scanning for /etc/fstab
+      expect(Yast::SCR).to receive(:Execute)
+        .with(Yast.path(".target.mount"), Array, "-o ro")
+        .and_return(false)
+
+      fs = Y2Storage::StorageManager.instance.probed.blk_filesystems.first
+      allow(fs).to receive(:type).and_return(Y2Storage::Filesystems::Type::EXT2)
+
+      subject.CheckPartition(fs)
+    end
+  end
 end


### PR DESCRIPTION
- Just merging #179 from SP3 to SP4
- https://bugzilla.suse.com/show_bug.cgi?id=1195894
- Use the `norecovery` mount option when searching the root partitions
