### PR TITLE
Warn when removing orphaned 3rd party packages (bsc#1202007)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 15 09:40:14 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Display a warning in the upgrade summary when removing orphaned
+  3rd party packages (bsc#1202007)
+- 4.4.8
+
+-------------------------------------------------------------------
 Thu Aug  4 15:06:09 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Use the "norecovery" mount option when searching the root

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.4.7
+Version:        4.4.8
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST
@@ -52,8 +52,8 @@ Requires:       yast2 >= 4.4.25
 Requires:       yast2-installation
 # ProductSpec#register_target
 Requires:       yast2-packager >= 4.4.15
-# Pkg::SetAdditionalVendors
-Requires:       yast2-pkg-bindings >= 4.3.3
+# filtering orphaned packages
+Requires:       yast2-pkg-bindings >= 4.4.5
 Requires:       yast2-ruby-bindings >= 1.0.0
 # nokogiri is used for parsing pam conf.
 Requires:  rubygem(%{rb_default_ruby_abi}:nokogiri)

--- a/src/clients/packages_proposal.rb
+++ b/src/clients/packages_proposal.rb
@@ -220,6 +220,8 @@ module Yast
         @ret
       end
 
+    private
+
       def call_packageselector
         options = {}
 
@@ -238,7 +240,7 @@ module Yast
         ret
       end
 
-      # Summary with with the list of uninstalled 3rd party packages
+      # Summary with the list of uninstalled 3rd party packages
       # @return [String,nil] Rich text summary or `nil` if no 3rd party package
       #   is uninstalled
       def orphaned_packages_warning
@@ -247,14 +249,14 @@ module Yast
 
         list = HTML.List(orphaned_packages_summary(orphaned_packages))
         # TRANSLATORS: warning displayed in the upgrade summary, this informs the
-        # user that some manually installed non-SUSE packages will uninstalled,
+        # user that some manually installed non-SUSE packages will be uninstalled,
         # user should check if that is OK, it is possible to manually change the
         # package status and keep it in the system
         _("<b>Warning: These packages will be removed:</b> %s") % list
       end
 
       # find the orphaned non-SUSE packages which will be uninstalled from the system
-      # @return [Y2Packager::Resolvable] list of orphaned packages
+      # @return [Array<Y2Packager::Resolvable>] list of orphaned packages
       def find_orphaned_packages
         # preload the "vendor" attribute so the vendor matching below is faster
         orphaned = Y2Packager::Resolvable.find(
@@ -276,6 +278,7 @@ module Yast
       # let's display just first few packages in the summary, the full list can be
       # displayed in the package manager
       ORPHANED_MAX_SIZE = 10
+      private_constant :ORPHANED_MAX_SIZE
 
       # create summary list
       # @param packages [Array<Y2Packager::Resolvable>] list of packages

--- a/src/clients/packages_proposal.rb
+++ b/src/clients/packages_proposal.rb
@@ -23,7 +23,6 @@
 #
 # Purpose:  Let user choose packages during update.
 #
-# $Id$
 
 require "y2packager/resolvable"
 
@@ -160,6 +159,10 @@ module Yast
             }
           }
 
+          # add a warning about orphaned packages if there is any
+          orphaned_warning = orphaned_packages_warning
+          @warning << orphaned_warning if orphaned_warning
+
           if Ops.greater_than(Update.solve_errors, 0)
             # the proposal for the packages requires manual invervention
             @ret.merge!(
@@ -233,6 +236,68 @@ module Yast
         end
 
         ret
+      end
+
+      # Summary with with the list of uninstalled 3rd party packages
+      # @return [String,nil] Rich text summary or `nil` if no 3rd party package
+      #   is uninstalled
+      def orphaned_packages_warning
+        orphaned_packages = find_orphaned_packages
+        return nil if orphaned_packages.empty?
+
+        list = HTML.List(orphaned_packages_summary(orphaned_packages))
+        # TRANSLATORS: warning displayed in the upgrade summary, this informs the
+        # user that some manually installed non-SUSE packages will uninstalled,
+        # user should check if that is OK, it is possible to manually change the
+        # package status and keep it in the system
+        _("<b>Warning: These packages will be removed:</b> %s") % list
+      end
+
+      # find the orphaned non-SUSE packages which will be uninstalled from the system
+      # @return [Y2Packager::Resolvable] list of orphaned packages
+      def find_orphaned_packages
+        # preload the "vendor" attribute so the vendor matching below is faster
+        orphaned = Y2Packager::Resolvable.find(
+          { kind: :package, status: :removed, orphaned: true },
+          [:vendor]
+        )
+        # ignore SUSE or openSUSE packages, but include packages from OBS projects
+        # where vendor is like "obs://build.opensuse.org/YaST",
+        # the SUSE Hub packages use the "openSUSE" vendor
+        orphaned.reject! { |o| o.vendor.start_with?("SUSE") || o.vendor.start_with?("openSUSE") }
+        # sort the packages alphabetically by name for easier reading (case insensitive)
+        orphaned.sort_by! { |o| o.name.downcase }
+        log.info "Found #{orphaned.size} non-SUSE orphaned packages: " +
+          orphaned.map { |p| package_label(p) }.to_s
+        orphaned
+      end
+
+      # limit the list of the displayed orphaned packages, the list might be potentially huge,
+      # let's display just first few packages in the summary, the full list can be
+      # displayed in the package manager
+      ORPHANED_MAX_SIZE = 10
+
+      # create summary list
+      # @param packages [Array<Y2Packager::Resolvable>] list of packages
+      # @return [Array<String>] list of text items
+      def orphaned_packages_summary(packages)
+        summary = packages.first(ORPHANED_MAX_SIZE).map { |p| package_label(p) }
+
+        if packages.size > ORPHANED_MAX_SIZE
+          # TRANSLATORS: %s is replaced by a number of remaining items
+          summary << _("... and %s more") % (packages.size - ORPHANED_MAX_SIZE)
+        end
+
+        summary
+      end
+
+      # create short description label for a package
+      # @param package [Y2Packager::Resolvable] the package object
+      # @return [String] human readable package label
+      def package_label(package)
+        label = "#{package.name}-#{package.version}.#{package.arch}"
+        label << " (#{package.vendor})" if !package.vendor.empty?
+        label
       end
     end
   end


### PR DESCRIPTION
## Problem

- At upgrade the orphaned packages are removed, this might include 3rd party packages like Oracle database
- The removal is silent, no warning is displayed, if user does not check the details in the package manager then a nasty surprise might happen... :rage: 
- https://bugzilla.suse.com/show_bug.cgi?id=1202007

## Solution

- Display a warning in the upgrade summary with list of removed non-SUSE packages
- In case there are many packages to remove it displays only the first ten ones followed with item "... and more", users can check the full list in the package manager
- This change needs pkg-binding enhancement: https://github.com/yast/yast-pkg-bindings/pull/170

## Testing

- [x] Tested manually
- [x] Check the SUSE Hub packages vendor, it should be ignored too (SUSE Hub packages use `openSUSE` vendor, which is already handled)
- [x] Check orphaned package with a new updated version available (if a newer version is available then the package is not marked as orphaned)

## Screenshots

Using this new filtering options we can display a warning in the summary when removing non-SUSE packages:

![upgrade_warning](https://user-images.githubusercontent.com/907998/201882056-388465e8-aed7-48a4-8dcc-4dbf7bc3c236.png)

