### PR TITLE
Rebuild the RPM database during upgrade (--rebuilddb) (bsc#1209565)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 12 08:37:15 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Rebuild the RPM database during upgrade (--rebuilddb) (bsc#1209565)
+- 4.5.3
+
+-------------------------------------------------------------------
 Wed Nov 16 14:33:33 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Display a warning in the upgrade summary when removing orphaned

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.5.2
+Version:        4.5.3
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST
@@ -52,8 +52,8 @@ Requires:       yast2 >= 4.4.25
 Requires:       yast2-installation
 # ProductSpec#register_target
 Requires:       yast2-packager >= 4.4.15
-# filtering orphaned packages
-Requires:       yast2-pkg-bindings >= 4.5.1
+# "rebuild_db" option in Pkg.TargetInitializeOptions
+Requires:       yast2-pkg-bindings >= 4.5.2
 Requires:       yast2-ruby-bindings >= 1.0.0
 # nokogiri is used for parsing pam conf.
 Requires:  rubygem(%{rb_default_ruby_abi}:nokogiri)

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -459,6 +459,8 @@ module Yast
         # the target distribution from the base product to make the new service
         # repositories compatible with the base product at upgrade (bnc#881320)
         if Pkg.TargetInitializeOptions(Installation.destdir,
+          # enable DB rebuild at upgrade (bsc#1209565)
+          "rebuild_db"    => true,
           "target_distro" => target_distribution) != true
           # Target load failed, #466803
           Builtins.y2error("Pkg::TargetInitialize failed")

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -458,10 +458,10 @@ module Yast
         # override the current target distribution at the system and use
         # the target distribution from the base product to make the new service
         # repositories compatible with the base product at upgrade (bnc#881320)
-        if Pkg.TargetInitializeOptions(Installation.destdir,
+        if !Pkg.TargetInitializeOptions(Installation.destdir,
           # enable DB rebuild at upgrade (bsc#1209565)
           "rebuild_db"    => true,
-          "target_distro" => target_distribution) != true
+          "target_distro" => target_distribution)
           # Target load failed, #466803
           Builtins.y2error("Pkg::TargetInitialize failed")
           if Popup.AnyQuestion(


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1209565
- The RPM DB should be rebuilt during upgrade to ensure it is in a consistent state

## Solution

- Use the new "rebuild_db" option in `Pkg.TargetInitializeOptions()` (https://github.com/yast/yast-pkg-bindings/pull/172)

## Testing

- Tested manually,  during manual upgrade libzypp calls
```
[zypp::exec++] ExternalProgram.cc(start_program):260 Executing[C] 'rpm' '--root' '/' '--dbpath'
'/mnt/usr/lib/sysimage/rpm' '--rebuilddb' '-vv'
```
