### PR TITLE
Backport SP6

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -2,6 +2,7 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- 4.6.1
 
 -------------------------------------------------------------------
 Wed Apr 12 08:37:15 UTC 2023 - Ladislav Slezák <lslezak@suse.com>

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST


### PR DESCRIPTION
## Problem

SLE 15 SP6 branch is based on SLE15 SP5 maintenance branch. So fixes done in master can be sometimes useful also for SP6.


## Solution

just bump version as all master patches are already in SP5