### PR TITLE
[SLE15-SP5] Fixed reusing old repositories with new URL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ Lint/UnderscorePrefixedVariableName:
 
 # Offense count: 25
 Metrics/AbcSize:
-  Max: 188
+  Max: 190
 
 # Offense count: 23
 # Configuration parameters: CountComments, ExcludedMethods.
@@ -40,7 +40,7 @@ Metrics/ClassLength:
 
 # Offense count: 25
 Metrics/CyclomaticComplexity:
-  Max: 46
+  Max: 50
 
 # Offense count: 27
 # Configuration parameters: CountComments, ExcludedMethods.
@@ -54,7 +54,7 @@ Metrics/ModuleLength:
 
 # Offense count: 24
 Metrics/PerceivedComplexity:
-  Max: 55
+  Max: 60
 
 # Offense count: 49
 # Configuration parameters: EnforcedStyle.

--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Oct 27 13:58:30 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Drop the previously used repositories when going back to the
+  partition selection at upgrade, this ensures the repositories
+  are correctly reinitialized later (bsc#1215884)
+- 4.5.4
+
+-------------------------------------------------------------------
 Wed Apr 12 08:37:15 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Rebuild the RPM database during upgrade (--rebuilddb) (bsc#1209565)

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -28,6 +28,7 @@
 #    calling this module.
 require "yast"
 
+require "y2packager/medium_type"
 require "y2packager/original_repository_setup"
 require "y2packager/product_spec"
 require "y2packager/repository"
@@ -455,6 +456,10 @@ module Yast
 
       # New partition has been mounted
       if flavor == :update_dialog && ret == :next
+        # drop all loaded repositories after going back in SLE, the installation medium is added later
+        # FIXME: what to do in Leap? we need to keep the already added installation repository... :-/
+        Pkg.SourceFinishAll if !Y2Packager::MediumType.standard?
+
         # override the current target distribution at the system and use
         # the target distribution from the base product to make the new service
         # repositories compatible with the base product at upgrade (bnc#881320)

--- a/src/include/update/rootpart.rb
+++ b/src/include/update/rootpart.rb
@@ -456,8 +456,9 @@ module Yast
 
       # New partition has been mounted
       if flavor == :update_dialog && ret == :next
-        # drop all loaded repositories after going back in SLE, the installation medium is added later
-        # FIXME: what to do in Leap? we need to keep the already added installation repository... :-/
+        # drop all loaded repositories after going back in SLE, the installation
+        # medium is added later FIXME: what to do in Leap? we need to keep the
+        # already added installation repository... :-/
         Pkg.SourceFinishAll if !Y2Packager::MediumType.standard?
 
         # override the current target distribution at the system and use


### PR DESCRIPTION
## Problem

- During system upgrade, when reusing some of the old repositories with new URLs YaST still used the old packages.
- https://bugzilla.suse.com/show_bug.cgi?id=1215884

This is the dialog which allows reusing the old reposiotories, possibly with a new URL.
![sle_upgrade_repo_selection](https://github.com/yast/yast-update/assets/907998/f0b2dcc7-e1df-4d5e-a212-a4639363281a)

But when the user when in the workflow back and forth then this dialog was skipped and the old repository was used with the old URL. That could cause some dependency issues. The YaST repo URL was changed to point to the SP5 repository, but you can see the old SP4 URL and old 4.4.x package version in the details.
![sle_upgrade_broken_after_going_back](https://github.com/yast/yast-update/assets/907998/f66bf46d-89e0-44ad-95de-a14934006710)

## Solution

It turned out that the previously used repositories were not dropped early enough so the selection dialog was skipped and the old repository was used.

## Testing

- Tested manually in
  - Medium based upgrade SLE-15-SP5
  - SCC (online) upgrade SLE-15-SP5
  - Medium based upgrade Leap 15.5
- Going back and forth was fixed in SLE, but the problem remains in Leap. On the other hand it was completely broken there even without going back, now it at least works without going back so it is still better than it was. Fixing Leap is not trivial and I do not want to waste time here...

With the fix you can see the new SP5 URL and correct 4.5.x package version.
![sles_upgrade_fixed](https://github.com/yast/yast-update/assets/907998/115107cd-314c-4f23-8d94-270f6c382520)
