### PR TITLE
add product update summary to proposal (jsc#PED-3773)

### DIFF
--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Wed Jan 17 11:56:33 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
-- Show the partition selected for upgrade in the installation
+- Show the block device selected for upgrade in the installation
   proposal (jsc#PED-3773)
 - 4.6.3
 

--- a/package/yast2-update.changes
+++ b/package/yast2-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 17 11:56:33 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Show the partition selected for upgrade in the installation
+  proposal (jsc#PED-3773)
+- 4.6.3
+
+-------------------------------------------------------------------
 Tue Oct 31 08:36:56 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Drop the previously used repositories when going back to the

--- a/package/yast2-update.spec
+++ b/package/yast2-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-update
-Version:        4.6.2
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Update
 Group:          System/YaST

--- a/src/clients/update_proposal.rb
+++ b/src/clients/update_proposal.rb
@@ -187,8 +187,15 @@ module Yast
 
         products = Y2Packager::Resolvable.find(kind: :product)
         # stores the proposal text output
-        @summary_text = Packages.product_update_summary(products)
+        summary_text = Packages.product_update_summary(products)
           .map { |item| "<li>#{item}</li>" }.join
+        product_info = "<li>" + format(
+          _("Updating %{product} on root %{partition}"),
+          product:   RootPart.GetInfoOfSelected(:name),
+          partition: RootPart.selectedRootPartition
+        ) + "</li>"
+
+        summary_text = product_info + summary_text
 
         # recalculate the disk space usage data
         SpaceCalculation.GetPartitionInfo
@@ -203,7 +210,7 @@ module Yast
 
         @ret = {
           "preformatted_proposal" => Ops.add(
-            Ops.add(HTML.ListStart, @summary_text),
+            Ops.add(HTML.ListStart, summary_text),
             HTML.ListEnd
           ),
           "help"                  => @update_options_help


### PR DESCRIPTION
## Problem

In systems with multiple partitions and systems it is not visible in summary what system/partition will be updated.

trello: https://trello.com/c/8K5XiQej/3522-upgrade-show-the-partition-selected-for-upgrade-in-the-installation-proposal
jira: https://jira.suse.com/browse/PED-3773

## Solution

Add to Update section line with system and partition that is going to be upgraded.


## Testing

- *Tested manually*


## Screenshots

![show_partition](https://github.com/yast/yast-update/assets/478871/c8e9e5b5-8b1a-492b-9c03-cb78d88d1c12)


